### PR TITLE
Quick fix to logging bug

### DIFF
--- a/ultranest/integrator.py
+++ b/ultranest/integrator.py
@@ -1597,7 +1597,7 @@ class ReactiveNestedSampler(object):
                     maxradiussq=self.region.maxradiussq,
                     sample_u=u, sample_v=v, sample_logl=logl)
                 np.savetxt(debug_filename + '.csv', self.region.u, delimiter=',')
-                log.info("live points stored in %s.csv" % debug_filename)
+                self.logger.info("live points stored in %s.csv" % debug_filename)
                 warning_message = warning_message1 + (warning_message2 % ' (stored for you in %s.csv)') % debug_filename
             else:
                 warning_message = warning_message1 + warning_message2 % ''


### PR DESCRIPTION
`self.logger` is incorrectly listed as `log` on a single line, which raises an `AttributeError` if logging.

![image](https://user-images.githubusercontent.com/16804223/101099415-9a96bf00-3592-11eb-98d7-8ec3f2eff272.png)

I haven't fully tested this solution, but it seems straightforward, so I took the liberty of opening a pull request.