### PR TITLE
update corner requirements to allow installation in python2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,12 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['numpy', 'cython', 'matplotlib', 'corner']
+requirements = ['numpy', 
+                'cython', 
+                'matplotlib', 
+                'corner<=2.1.0; python_version <= "2.7"',
+                'corner; python_version > "3.0"',
+               ]
 
 setup_requirements = ['pytest-runner', ]
 


### PR DESCRIPTION
python2.7 is soon to be dropped by most projects, however, ultranest currently works in python2.7, and we use this in downstream testing. A recent release of corner (2.2.0) prevents unpinned dependency on it as it has become incompatible with python2.7 without declaring as such on pypi. This patch should allow the next release of ultranest to be installable through pypi on python2.7 again without separately installing corner. 