### PR TITLE
Loop over `run` folders to find next available

### DIFF
--- a/ultranest/utils.py
+++ b/ultranest/utils.py
@@ -68,7 +68,7 @@ def _makedirs(name):
     # os.makedirs(name, exist_ok=True)
 
 
-def make_run_dir(log_dir, run_num=None, append_run_num=True):
+def make_run_dir(log_dir, run_num=None, append_run_num=True, max_run_num=10000):
     """Generate a new numbered directory for this run to store output.
 
     Parameters
@@ -79,6 +79,8 @@ def make_run_dir(log_dir, run_num=None, append_run_num=True):
         folder to add to path, such as prefix/1/
     append_run_num: bool
         If true, set run_num to next unused number
+    max_run_num: int
+        Maximum number of automatic run subfolders
 
     Returns
     -------
@@ -90,15 +92,15 @@ def make_run_dir(log_dir, run_num=None, append_run_num=True):
     _makedirs(log_dir)
 
     if run_num is None or run_num == '':
-        # loop over existing folders of the form log_dir/runX
+        # loop over existing folders (or files) of the form log_dir/runX
         # to find next available run_num (up to the hardcoded maximum of 1000)
-        for run_num in range(1,1000):
-            if os.path.isdir(os.path.join(log_dir, 'run%s' % run_num)):
+        for run_num in range(1, max_run_num):
+            if os.path.exists(os.path.join(log_dir, 'run%s' % run_num)):
                 continue
             else:
                 break
          else:
-             raise ValueError('log directory already contains maximum number of run subdirectories')
+             raise ValueError("log directory '%s' already contains maximum number of run subdirectories (%d)" % (log_dir, max_run_num))
     if append_run_num:
         run_dir = os.path.join(log_dir, 'run%s' % run_num)
     else:

--- a/ultranest/utils.py
+++ b/ultranest/utils.py
@@ -76,7 +76,7 @@ def make_run_dir(log_dir, run_num=None, append_run_num=True, max_run_num=10000):
     log_dir: str
         base path
     run_num: int
-        folder to add to path, such as prefix/1/
+        folder to add to path, such as prefix/run1/
     append_run_num: bool
         If true, set run_num to next unused number
     max_run_num: int

--- a/ultranest/utils.py
+++ b/ultranest/utils.py
@@ -90,8 +90,13 @@ def make_run_dir(log_dir, run_num=None, append_run_num=True):
     _makedirs(log_dir)
 
     if run_num is None or run_num == '':
-        run_num = (sum(os.path.isdir(os.path.join(log_dir,i))
-                       for i in os.listdir(log_dir)) + 1)
+        for run_num in range(1,1000):
+            if os.path.isdir(os.path.join(log_dir, 'run%s' % run_num)):
+                continue
+            else:
+                break
+         else:
+             raise ValueError('log directory already contains maximum number of run subdirectories')
     if append_run_num:
         run_dir = os.path.join(log_dir, 'run%s' % run_num)
     else:

--- a/ultranest/utils.py
+++ b/ultranest/utils.py
@@ -90,6 +90,8 @@ def make_run_dir(log_dir, run_num=None, append_run_num=True):
     _makedirs(log_dir)
 
     if run_num is None or run_num == '':
+        # loop over existing folders of the form log_dir/runX
+        # to find next available run_num (up to the hardcoded maximum of 1000)
         for run_num in range(1,1000):
             if os.path.isdir(os.path.join(log_dir, 'run%s' % run_num)):
                 continue


### PR DESCRIPTION
Rather than adding up the number of objects in the log directory to work out the next one, this makes the code loop from 1 to find the first available directory of the form `runX`. There's a a hard maximum of 1000, to guarantee termination, after which the code raises an error. Feel free to change this (or make it a parameter): I'm not sure if anyone might want to store more than 1000 runs.

You may also want to raise a different kind of error.

This is intended to resolve issue #33.