### PR TITLE
Fix uneven splitting of loglike evaluations

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,9 @@ import numpy as np
 import tempfile
 import os
 from ultranest.utils import vectorize, is_affine_transform, normalised_kendall_tau_distance, make_run_dir
+from ultranest.utils import todo_points_for_this_process
 from numpy.testing import assert_allclose
-
+import pytest
 
 def test_vectorize():
 	
@@ -63,3 +64,12 @@ def test_make_log_dirs():
 			pass
 	finally:
 		shutil.rmtree(filepath)
+
+@pytest.mark.parametrize("mpi_size", [1, 4, 10, 100, 1000, 515, 14365, 13512, 86400])
+@pytest.mark.parametrize("num_live_points_missing", [0, 1, 4, 10, 100, 1000, 515, 14365, 13512, 86400])
+def test_todo_points_for_this_process(mpi_size, num_live_points_missing):
+    processes = range(mpi_size)
+    todo = [todo_points_for_this_process(rank, num_live_points_missing, mpi_size) for rank in processes]
+    assert sum(todo) == num_live_points_missing
+    assert max(todo) - min(todo) in {0, 1}
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import tempfile
 import os
 from ultranest.utils import vectorize, is_affine_transform, normalised_kendall_tau_distance, make_run_dir
-from ultranest.utils import todo_points_for_this_process
+from ultranest.utils import distributed_work_chunk_size
 from numpy.testing import assert_allclose
 import pytest
 
@@ -65,11 +65,11 @@ def test_make_log_dirs():
 	finally:
 		shutil.rmtree(filepath)
 
-@pytest.mark.parametrize("mpi_size", [1, 4, 10, 100, 1000, 515, 14365, 13512, 86400])
-@pytest.mark.parametrize("num_live_points_missing", [0, 1, 4, 10, 100, 1000, 515, 14365, 13512, 86400])
-def test_todo_points_for_this_process(mpi_size, num_live_points_missing):
+@pytest.mark.parametrize("mpi_size", [1, 4, 10, 37, 53, 100, 1000, 513])
+@pytest.mark.parametrize("num_live_points_missing", [0, 1, 4, 10, 17, 31, 100, 1000, 513])
+def test_distributed_work_chunk_size(mpi_size, num_live_points_missing):
     processes = range(mpi_size)
-    todo = [todo_points_for_this_process(rank, num_live_points_missing, mpi_size) for rank in processes]
+    todo = [distributed_work_chunk_size(num_live_points_missing, rank, mpi_size) for rank in processes]
     assert sum(todo) == num_live_points_missing
     assert max(todo) - min(todo) in {0, 1}
 

--- a/ultranest/integrator.py
+++ b/ultranest/integrator.py
@@ -1337,12 +1337,8 @@ class ReactiveNestedSampler(object):
         if self.log and num_live_points_missing > 0:
             self.logger.info('Sampling %d live points from prior ...', num_live_points_missing)
         if num_live_points_missing > 0:
-            if self.mpi_rank != 0:
-                num_live_points_todo = num_live_points_missing // self.mpi_size
-            else:
-                # rank 0 picks up what the others did not do
-                num_live_points_todo = num_live_points_missing - (num_live_points_missing // self.mpi_size) * (self.mpi_size - 1)
-
+            num_live_points_todo = (num_live_points_missing + self.mpi_size - 1 - self.mpi_rank) // self.mpi_size
+ 
             active_u = np.random.uniform(size=(num_live_points_todo, self.x_dim))
             active_v = self.transform(active_u)
             active_logl = self.loglike(active_v)

--- a/ultranest/integrator.py
+++ b/ultranest/integrator.py
@@ -17,7 +17,7 @@ from numpy import log, exp, logaddexp
 import numpy as np
 
 from .utils import create_logger, make_run_dir, resample_equal, vol_prefactor, vectorize, listify as _listify
-from .utils import is_affine_transform, normalised_kendall_tau_distance, todo_points_for_this_process
+from .utils import is_affine_transform, normalised_kendall_tau_distance, distributed_work_chunk_size
 from ultranest.mlfriends import MLFriends, AffineLayer, ScalingLayer, find_nearby, WrappingEllipsoid, RobustEllipsoidRegion
 from .store import HDF5PointStore, TextPointStore, NullPointStore
 from .viz import get_default_viz_callback, nicelogger
@@ -1337,7 +1337,7 @@ class ReactiveNestedSampler(object):
         if self.log and num_live_points_missing > 0:
             self.logger.info('Sampling %d live points from prior ...', num_live_points_missing)
         if num_live_points_missing > 0:
-            num_live_points_todo = todo_points_for_this_process(self.mpi_rank, num_live_points_missing, self.mpi_size)
+            num_live_points_todo = distributed_work_chunk_size(num_live_points_missing, self.mpi_rank, self.mpi_size)
 
             active_u = np.random.uniform(size=(num_live_points_todo, self.x_dim))
             active_v = self.transform(active_u)

--- a/ultranest/integrator.py
+++ b/ultranest/integrator.py
@@ -17,7 +17,7 @@ from numpy import log, exp, logaddexp
 import numpy as np
 
 from .utils import create_logger, make_run_dir, resample_equal, vol_prefactor, vectorize, listify as _listify
-from .utils import is_affine_transform, normalised_kendall_tau_distance
+from .utils import is_affine_transform, normalised_kendall_tau_distance, todo_points_for_this_process
 from ultranest.mlfriends import MLFriends, AffineLayer, ScalingLayer, find_nearby, WrappingEllipsoid, RobustEllipsoidRegion
 from .store import HDF5PointStore, TextPointStore, NullPointStore
 from .viz import get_default_viz_callback, nicelogger
@@ -1337,8 +1337,8 @@ class ReactiveNestedSampler(object):
         if self.log and num_live_points_missing > 0:
             self.logger.info('Sampling %d live points from prior ...', num_live_points_missing)
         if num_live_points_missing > 0:
-            num_live_points_todo = (num_live_points_missing + self.mpi_size - 1 - self.mpi_rank) // self.mpi_size
- 
+            num_live_points_todo = todo_points_for_this_process(self.mpi_rank, num_live_points_missing, self.mpi_size)
+
             active_u = np.random.uniform(size=(num_live_points_todo, self.x_dim))
             active_v = self.transform(active_u)
             active_logl = self.loglike(active_v)

--- a/ultranest/utils.py
+++ b/ultranest/utils.py
@@ -441,3 +441,18 @@ def verify_gradient(ndim, transform, loglike, gradient, verbose=False, combinati
             print("expectation was L=", Lexpected, ", given", Lref, grad, eps)
         assert np.allclose(Lprime, Lexpected, atol=0.1 / ndim), \
             (u, uprime, theta, thetaprime, grad, eps * grad / L, L, Lprime, Lexpected)
+
+def todo_points_for_this_process(mpi_rank, num_live_points_missing, mpi_size):
+    """
+    Calculates number of living points to be evaluated by this process.
+
+    Parameters
+    ----------
+    mpi_rank : int
+        process id
+    num_live_points_missing : int
+        number of live points to be splitted
+    mpi_size : int
+        total number of processes
+    """
+    return (num_live_points_missing + mpi_size - 1 - mpi_rank) // mpi_size

--- a/ultranest/utils.py
+++ b/ultranest/utils.py
@@ -442,17 +442,18 @@ def verify_gradient(ndim, transform, loglike, gradient, verbose=False, combinati
         assert np.allclose(Lprime, Lexpected, atol=0.1 / ndim), \
             (u, uprime, theta, thetaprime, grad, eps * grad / L, L, Lprime, Lexpected)
 
-def todo_points_for_this_process(mpi_rank, num_live_points_missing, mpi_size):
+def distributed_work_chunk_size(num_total_tasks, mpi_rank, mpi_size):
     """
-    Calculates number of living points to be evaluated by this process.
+    Computes the number of tasks for process number `mpi_rank`, so that
+    `num_total_tasks` tasks are spread uniformly among `mpi_size` processes.
 
     Parameters
     ----------
+    num_total_tasks : int
+        total number of tasks to be split
     mpi_rank : int
         process id
-    num_live_points_missing : int
-        number of live points to be splitted
     mpi_size : int
         total number of processes
     """
-    return (num_live_points_missing + mpi_size - 1 - mpi_rank) // mpi_size
+    return (num_total_tasks + mpi_size - 1 - mpi_rank) // mpi_size


### PR DESCRIPTION
Fix uneven splitting of loglike evaluations while calculating the initial living points likelihood (#42).