### PR TITLE
add pyproject.toml file to enable better pip installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-	"setuptools",
+        "setuptools",
         "wheel",
-	"cython",
-	"oldest-supported-numpy",
+        "cython",
+        "oldest-supported-numpy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
 	"setuptools",
+        "wheel",
 	"cython",
 	"oldest-supported-numpy",
 ]


### PR DESCRIPTION
This adds a boiler plate pyproject.toml file to ensure that pip can install dependencies for the build process of UltraNest. This has largely been pulled from a project I work on (pycbc), but looking at UltraNest's setup.py, it looks like the same set of dependencies are used. 

This can tested with 

```
pip install .
```