### PR TITLE
Fix encoding error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,10 @@ ext_args = dict(
 )
 
 
-with open('README.rst') as readme_file:
+with open('README.rst', encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with open('HISTORY.rst', encoding="utf-8") as history_file:
     history = history_file.read()
 
 requirements = ['numpy', 'cython', 'matplotlib', 'corner']


### PR DESCRIPTION
I was trying to install from pip at first and encountered UnicodeDecodeError when build wheels. Then I tried building from source code and found this tiny issue. Even though the codes are all using UTF-8 encoding, some command line tools (e.g. pip) tend to use system default encoding when dealing with I/O, so a `encoding="utf-8"` helps them stick to the UTF-8.

Changes:

What I've changed is in `setup.py` with addition of parameter `encoding="utf-8"` to `open()`.