### PR TITLE
Add scipy in requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ with open('README.rst', encoding="utf-8") as readme_file:
 with open('HISTORY.rst', encoding="utf-8") as history_file:
     history = history_file.read()
 
-requirements = ['numpy', 'cython', 'matplotlib', 'corner']
+requirements = ['numpy', 'cython', 'matplotlib', 'corner', 'scipy']
 
 setup_requirements = ['pytest-runner', ]
 


### PR DESCRIPTION
 I installed ultranest on a fresh environment and importing it requires scipy, so I add it the setup.py