### PR TITLE
use cpow director to ensure cython 3 compatibility

### DIFF
--- a/ultranest/mlfriends.pyx
+++ b/ultranest/mlfriends.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3,annotate=True,profile=True,fast_fail=True,warning_errors=True
+# cython: language_level=3,annotate=True,profile=True,fast_fail=True,warning_errors=True,cpow=True
 """
 Region construction methods
 ---------------------------


### PR DESCRIPTION
A possibly better alternative was suggested in https://github.com/JohannesBuchner/UltraNest/issues/102 by @PieterVuylsteke. 

This is a quick fix that may also work, please close this if the alternative is accepted. I did check that this seems to work in both cython3 and cython 0.29 so it's at least backwards compatible with the most relevant versions. 