### PR TITLE
Add the possibility to provide an ax for Band plots

### DIFF
--- a/ultranest/plot.py
+++ b/ultranest/plot.py
@@ -131,7 +131,7 @@ class PredictionBand(object):
         else:
             return ax.fill_between(self.x, lo, hi, **shadeargs)
 
-    def line(self, ax= None, **kwargs):
+    def line(self, ax=None, **kwargs):
         """Plot the median curve."""
         lineargs = dict(self.lineargs)
         lineargs.update(kwargs)

--- a/ultranest/plot.py
+++ b/ultranest/plot.py
@@ -78,7 +78,8 @@ class PredictionBand(object):
         for c in chain:
             band.add(c[0] * x + c[1])
         # add median line. As an option a matplotlib ax can be given.
-        band.line(color='k') # or band.line(color='k', ax = ax)
+        band.line(color='k')
+        # to plot onto a specific axis, use `band.line(..., ax=myaxis)`
         # add 1 sigma quantile
         band.shade(color='k', alpha=0.3)
         # add wider quantile

--- a/ultranest/plot.py
+++ b/ultranest/plot.py
@@ -118,22 +118,28 @@ class PredictionBand(object):
         assert len(self.ys) > 0, self.ys
         return scipy.stats.mstats.mquantiles(self.ys, q, axis=0)[0]
 
-    def shade(self, q=0.341, **kwargs):
+   def shade(self, q=0.341, ax=None, **kwargs):
         """Plot a shaded region between 0.5-q and 0.5+q. Default is 1 sigma."""
         if not 0 <= q <= 0.5:
-            raise ValueError("quantile distance from the median, q, must be between 0 and 0.5, not %s. For a 99%% quantile range, use q=0.48." % q)
+            raise ValueError("quantile distance from the median, q, must be between 0 and 0.5, not %s. For a 99% quantile range, use q=0.48." % q)
         shadeargs = dict(self.shadeargs)
         shadeargs.update(kwargs)
         lo = self.get_line(0.5 - q)
         hi = self.get_line(0.5 + q)
-        return plt.fill_between(self.x, lo, hi, **shadeargs)
+        if ax is None:
+            return plt.fill_between(self.x, lo, hi, **shadeargs)
+        else:
+            return ax.fill_between(self.x, lo, hi, **shadeargs)
 
-    def line(self, **kwargs):
+    def line(self, ax= None, **kwargs):
         """Plot the median curve."""
         lineargs = dict(self.lineargs)
         lineargs.update(kwargs)
         mid = self.get_line(0.5)
-        return plt.plot(self.x, mid, **lineargs)
+        if ax is None:
+            return plt.plot(self.x, mid, **lineargs)
+        else:
+            return ax.plot(self.x, mid, **lineargs)
 
 
 # the following function is taken from https://github.com/joshspeagle/dynesty/blob/master/dynesty/plotting.py

--- a/ultranest/plot.py
+++ b/ultranest/plot.py
@@ -77,8 +77,8 @@ class PredictionBand(object):
         band = PredictionBand(x)
         for c in chain:
             band.add(c[0] * x + c[1])
-        # add median line
-        band.line(color='k')
+        # add median line. As an option a matplotlib ax can be given.
+        band.line(color='k') # or band.line(color='k', ax = ax)
         # add 1 sigma quantile
         band.shade(color='k', alpha=0.3)
         # add wider quantile
@@ -127,9 +127,8 @@ class PredictionBand(object):
         lo = self.get_line(0.5 - q)
         hi = self.get_line(0.5 + q)
         if ax is None:
-            return plt.fill_between(self.x, lo, hi, **shadeargs)
-        else:
-            return ax.fill_between(self.x, lo, hi, **shadeargs)
+            ax = plt
+        return ax.fill_between(self.x, lo, hi, **shadeargs)
 
     def line(self, ax=None, **kwargs):
         """Plot the median curve."""
@@ -137,9 +136,8 @@ class PredictionBand(object):
         lineargs.update(kwargs)
         mid = self.get_line(0.5)
         if ax is None:
-            return plt.plot(self.x, mid, **lineargs)
-        else:
-            return ax.plot(self.x, mid, **lineargs)
+            ax = plt
+        return ax.plot(self.x, mid, **lineargs)
 
 
 # the following function is taken from https://github.com/joshspeagle/dynesty/blob/master/dynesty/plotting.py


### PR DESCRIPTION
Hi,

After performing an analysis with BXA of X-ray spectral data,  I'm tryring to perfom band plots in the Sherpa environment.
What I do is a `plot_fit_ratio()` which plots the model in a panel and the residuals in another panel.
When calling `band.line` the plot is added to the 2nd residual panel and not on the spectral data as I intended.

Looking at UltraNest `plot.py`, I added a keyword `ax=None` to allow to select the ax where the line or shade will be overlaid.

Let me know if you think this is a useful addition and if you recommend some modifications (or if there is a way to do that without my PR).
I don't think this needs extra tests.
Maybe the Example in the class docstring could be updated to show that it is possible. 
Let me know what you think.