### PR TITLE
Added NumpyEncoder to json.dump

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from ultranest.utils import distributed_work_chunk_size
 from ultranest.utils import NumpyEncoder
 from numpy.testing import assert_allclose
 import pytest
+import json
 
 def test_vectorize():
     
@@ -145,3 +146,24 @@ def test_numpy_encoder():
         pass
     else:
         assert False, "TypeError not raised for non-numpy types."
+
+
+def test_numpy_encoder_with_json():
+
+    numpy_integer = np.int32(1)
+    numpy_float = np.float32(1.0)
+    numpy_array = np.array([1, 2, 3])
+
+    json_string = json.dumps(
+        {
+            "numpy_integer": numpy_integer,
+            "numpy_float": numpy_float,
+            "numpy_array": numpy_array,
+        },
+        cls=NumpyEncoder,
+    )
+
+    assert (
+        json_string
+        == '{"numpy_integer": 1, "numpy_float": 1.0, "numpy_array": [1, 2, 3]}'
+    ), "JSON string not as expected."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import tempfile
 import os
 from ultranest.utils import vectorize, is_affine_transform, normalised_kendall_tau_distance, make_run_dir, verify_gradient
 from ultranest.utils import distributed_work_chunk_size
+from ultranest.utils import NumpyEncoder
 from numpy.testing import assert_allclose
 import pytest
 
@@ -118,3 +119,29 @@ def test_distributed_work_chunk_size(mpi_size, num_live_points_missing):
     todo = [distributed_work_chunk_size(num_live_points_missing, rank, mpi_size) for rank in processes]
     assert sum(todo) == num_live_points_missing
     assert max(todo) - min(todo) in {0, 1}
+
+def test_numpy_encoder():
+    encoder = NumpyEncoder()
+    numpy_integer = np.int32(1)
+    numpy_float = np.float32(1.0)
+    numpy_array = np.array([1, 2, 3])
+    normal_obj = "normal object"
+
+    assert encoder.default(numpy_integer) == int(
+        numpy_integer
+    ), "Numpy integer not correctly converted."
+
+    assert encoder.default(numpy_float) == float(
+        numpy_float
+    ), "Numpy float not correctly converted."
+
+    assert encoder.default(numpy_array) == list(
+        numpy_array
+    ), "Numpy array not correctly converted."
+
+    try:
+        encoder.default(normal_obj)
+    except TypeError:
+        pass
+    else:
+        assert False, "TypeError not raised for non-numpy types."

--- a/ultranest/integrator.py
+++ b/ultranest/integrator.py
@@ -24,7 +24,7 @@ from numpy import log, exp, logaddexp
 import numpy as np
 
 from .utils import create_logger, make_run_dir, resample_equal, vol_prefactor, vectorize, listify as _listify
-from .utils import is_affine_transform, normalised_kendall_tau_distance, distributed_work_chunk_size
+from .utils import is_affine_transform, normalised_kendall_tau_distance, distributed_work_chunk_size, NumpyEncoder
 from ultranest.mlfriends import MLFriends, AffineLayer, LocalAffineLayer, ScalingLayer, find_nearby, WrappingEllipsoid, RobustEllipsoidRegion
 from .store import HDF5PointStore, TextPointStore, NullPointStore
 from .viz import get_default_viz_callback
@@ -2882,7 +2882,7 @@ class ReactiveNestedSampler(object):
                        comments='')
 
             with open(os.path.join(self.logs['info'], 'results.json'), 'w') as f:
-                json.dump(results_simple, f, indent=4)
+                json.dump(results_simple, f, indent=4, cls=NumpyEncoder)
 
             np.savetxt(
                 os.path.join(self.logs['info'], 'post_summary.csv'),

--- a/ultranest/utils.py
+++ b/ultranest/utils.py
@@ -10,6 +10,7 @@ import os
 import numpy as np
 from numpy import pi
 import errno
+import json
 
 
 def create_logger(module_name, log_dir=None, level=logging.INFO):
@@ -492,3 +493,27 @@ def submasks(mask, *masks):
     for othermask in masks:
         indices = indices[othermask]
     return indices
+
+
+class NumpyEncoder(json.JSONEncoder):
+    """
+    Custom JSON Encoder for NumPy data types.
+
+    This encoder extends the default JSONEncoder to handle NumPy's
+    numeric types (integers, floats) and arrays, converting them
+    to native Python types that are JSON serializable.
+
+    Methods
+    -------
+    default(obj)
+        Converts NumPy types to Python types for JSON serialization.
+    """
+    def default(self, obj):
+        # Handle all numpy numeric types
+        if isinstance(obj, (np.integer, np.floating)):
+            return obj.item()
+        # Handle numpy arrays
+        elif isinstance(obj, np.ndarray):
+            return obj.tolist()
+        # Fall back to the default behavior
+        return super().default(obj)


### PR DESCRIPTION
This PR adds a numpy encoder to the `json.dump` of the results, addressing the issue highlighted in the 1st comment of #135 . In particular, it now allows to run with float32 precision which is the default in JAX and often a preferred option on GPUs when speed and efficiency are relevant.