### PR TITLE
Draft: Results dictionary explanation

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -98,16 +98,7 @@ If a `log_dir` directory was specified, you will find these files:
 * info folder: machine-readable summaries of the posterior
 
   * **post_summary.csv**: for each parameter: mean, std, median, upper and lower 1 sigma error. Can be read with `pandas.read_csv <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html>`_.
-  * **results.json**: Contains detailed output of the nested sampling run. Can be read with `json.load <https://docs.python.org/3/library/json.html>`_.
-
-    * paramnames: parameter names
-    * ncall, niter: Number of likelihood calls, nested sampling iterations
-    * maximum_likelihood: highest loglikelihood point found so far
-    * H, Herr: (global) information gain
-    * ess: effective sample size
-    * logz, logzerr: ln(Z) and its uncertainty. logzerr_tail is the remainder integral contribution, logzerr_bs is from bootstrapping
-    * posterior: for each parameter: mean, std, median, upper and lower 1 sigma error, and `information gain <https://arxiv.org/abs/2205.00009>`_.
-    * insertion_order_MWW_test: MWW test results (see Buchner+21 in prep)
+  * **results.json**: Contains detailed output of the nested sampling run, with all the same keys as the result dictionary in :py:meth:`ultranest.integrator.ReactiveNestedSampler.run`, except for ``samples`` and ``weighted_samples`` (as the sample information is saved in separate files - see the following entries in this list). Can be read with `json.load <https://docs.python.org/3/library/json.html>`_.
 
 * chains: machine-readable chains
 

--- a/ultranest/integrator.py
+++ b/ultranest/integrator.py
@@ -2386,13 +2386,13 @@ class ReactiveNestedSampler:
             - niter (int): number of sampler iterations
             - ncall (int): total number of likelihood evaluations (accepted and not)
             - logz (float64): natural logarithm of the evidence :math:`\log Z = \log \int p(d|\theta) p(\theta) \text{d}\theta`
-            - logzerr (float64): :math:`1\sigma` error on :math:`\log Z` (`can be safely assumed to be Gaussian <https://github.com/JohannesBuchner/UltraNest/issues/63>`_)
+            - logzerr (float64): global estimate of the :math:`1\sigma` error on :math:`\log Z` (`can be safely assumed to be Gaussian <https://github.com/JohannesBuchner/UltraNest/issues/63>`_); obtained as the quadratic mean of ``logz_bs`` and ``logz_tail``
             - logz_bs (float64): estimate of :math:`\log Z` from bootstrapping - for details, see the `ultranest paper <https://joss.theoj.org/papers/10.21105/joss.03001>`_
             - logzerr_bs (float64): estimate of the error on the  of :math:`\log Z` from bootstrapping
             - logz_single (float64): estimate of :math:`\log Z` from a single sampler
             - logzerr_single (float64): estimate of the error :math:`\log Z` from a single sampler
             - logzerr_tail (float64): contribution of the tail (i.e. the terminal leaves of the tree) to the error on :math:`\log Z` (?)
-            - ess (float64): effective sample size, i.e. number of samples divided by the estimated correlation length
+            - ess (float64): effective sample size, i.e. number of samples divided by the estimated correlation length, estimated as :math:`N / (1 + N^{-1} \sum_i (N w_i - 1)^2)`
             - H (float64): `information gained <https://arxiv.org/abs/2205.00009>`_
             - Herr (float64): (Gaussian) :math:`1\sigma` error on :math:`H`
             - posterior (dict): summary information on the posterior marginal distributions for each parameter - a dictionary of lists each with as many items as the fit parameters, indexed as :math:`\theta_i` in the following:

--- a/ultranest/integrator.py
+++ b/ultranest/integrator.py
@@ -2502,11 +2502,10 @@ class ReactiveNestedSampler:
 
         Yields
         ------
-
         results (dict):
             Results dictionary computed at the current iteration, with the same
             keys as discussed in the :py:meth:`run` method.
-"""
+        """
         # frac_remain=1  means 1:1 -> dlogz=log(0.5)
         # frac_remain=0.1 means 1:10 -> dlogz=log(0.1)
         # dlogz_min = log(1./(1 + frac_remain))

--- a/ultranest/integrator.py
+++ b/ultranest/integrator.py
@@ -2382,39 +2382,63 @@ class ReactiveNestedSampler:
         ------
         results (dict): Results dictionary, with the following entries:
 
-            - samples (ndarray): re-weighted posterior samples: distributed according to :math:`p(\theta | d)` - these points are not sorted, and can be assumed to have been randomly shuffled. See :py:func:`ultranest.utils.resample_equal` for more details.
-            - logz (float64): natural logarithm of the evidence :math:`\log Z = \log \int p(d|\theta) p(\theta) \text{d}\theta`
-            - logzerr (float64): global estimate of the :math:`1\sigma` error on :math:`\log Z` (`can be safely assumed to be Gaussian <https://github.com/JohannesBuchner/UltraNest/issues/63>`_); obtained as the quadratic sum of ``logz_bs`` and ``logz_tail``. Users are advised to use ``logz`` :math:`\pm` ``logzerr`` as the best estimate for the evidence and its error.
+            - samples (ndarray): re-weighted posterior samples: distributed according
+            to :math:`p(\theta | d)` - these points are not sorted, and can be assumed
+            to have been randomly shuffled.
+            See :py:func:`ultranest.utils.resample_equal` for more details.
+            - logz (float64): natural logarithm of the evidence
+            :math:`\log Z = \log \int p(d|\theta) p(\theta) \text{d}\theta`
+            - logzerr (float64): global estimate of the :math:`1\sigma` error on
+            :math:`\log Z`
+            (`can be safely assumed to be Gaussian <https://github.com/JohannesBuchner/UltraNest/issues/63>`_);
+            obtained as the quadratic sum of ``logz_bs`` and ``logz_tail``.
+            Users are advised to use ``logz`` :math:`\pm` ``logzerr``
+            as the best estimate for the evidence and its error.
             - niter (int): number of sampler iterations
             - ncall (int): total number of likelihood evaluations (accepted and not)
-            - logz_bs (float64): estimate of :math:`\log Z` from bootstrapping - for details, see the `ultranest paper <https://joss.theoj.org/papers/10.21105/joss.03001>`_
-            - logzerr_bs (float64): estimate of the error on the  of :math:`\log Z` from bootstrapping
+            - logz_bs (float64): estimate of :math:`\log Z` from bootstrapping -
+            for details, see the
+            `ultranest paper <https://joss.theoj.org/papers/10.21105/joss.03001>`_
+            - logzerr_bs (float64): estimate of the error on the  of :math:`\log Z`
+            from bootstrapping
             - logz_single (float64): estimate of :math:`\log Z` from a single sampler
-            - logzerr_single (float64): estimate of the error :math:`\log Z` from a single sampler, obtained as :math:`\sqrt{H / n_{\text{live}}}`
-            - logzerr_tail (float64): contribution of the tail (i.e. the terminal leaves of the tree) to the error on :math:`\log Z` (?)
-            - ess (float64): effective sample size, i.e. number of samples divided by the estimated correlation length, estimated as :math:`N / (1 + N^{-1} \sum_i (N w_i - 1)^2)` where :math:`w_i` are the sample weights
+            - logzerr_single (float64): estimate of the error :math:`\log Z` from a
+            single sampler, obtained as :math:`\sqrt{H / n_{\text{live}}}`
+            - logzerr_tail (float64): contribution of the tail (i.e. the terminal
+            leaves of the tree) to the error on :math:`\log Z` (?)
+            - ess (float64): effective sample size, i.e. number of samples divided by
+            the estimated correlation length, estimated as
+            :math:`N / (1 + N^{-1} \sum_i (N w_i - 1)^2)` where :math:`w_i` are
+            the sample weights while :math:`N` is the number of samples
             - H (float64): `information gained <https://arxiv.org/abs/2205.00009>`_
             - Herr (float64): (Gaussian) :math:`1\sigma` error on :math:`H`
-            - posterior (dict): summary information on the posterior marginal distributions for each parameter - a dictionary of lists each with as many items as the fit parameters, indexed as :math:`\theta_i` in the following:
+            - posterior (dict): summary information on the posterior marginal distributions for each parameter -
+            a dictionary of lists each with as many items as the fit parameters,
+            indexed as :math:`\theta_i` in the following:
                 - mean (list): expectation value of :math:`\theta_i`
                 - stdev (list): standard deviation of :math:`\theta_i`
                 - median (list): median of :math:`\theta_i`
                 - errlo (list): one-sigma lower quantile of the marginal for :math:`\theta_i`, i.e. 15.8655% quantile
                 - errup (list): one-sigma upper quantile of the marginal for :math:`\theta_i`, i.e. 84.1345% quantile
                 - information_gain_bits (list): information gain from the marginal prior on :math:`\theta_i` to the posterior
-            - weighted_samples (dict): weighted samples from the posterior, as computed during sampling, sorted by their log-likelihood value
-                - upoints (ndarray): sample locations in the unit cube :math:`[0, 1]^{d}`, where $d$ is the number of parameters - the shape is ``n_iter`` by :math:`d`
+            - weighted_samples (dict): weighted samples from the posterior, as computed during sampling,
+            sorted by their log-likelihood value
+                - upoints (ndarray): sample locations in the unit cube :math:`[0, 1]^{d}`,
+                where :math:`d` is the number of parameters - the shape is ``n_iter`` by :math:`d`
                 - points (ndarray): sample locations in the physical, user-provided space (same shape as ``upoints``)
                 - weights (ndarray): sample weights - shape ``n_iter``, they sum to 1
                 - logw (ndarray): logs of the sample weights (?)
                 - bootstrapped_weights (ndarray): bootstrapped estimate of the sample weights
                 - logl (ndarray): log-likelihood values at the sample points
-            - maximum_likelihood (dict): summary information on the maximum likelihood value :math:`\theta_{ML}` found by the posterior exploration
+            - maximum_likelihood (dict): summary information on the maximum likelihood value
+            :math:`\theta_{ML}` found by the posterior exploration
                 - logl (float64): value of the log-likelihood at this point: :math:`\log p(d | \theta_{ML})`
                 - point (list): coordinates of :math:`\theta_{ML}` in the physical space
                 - point_untransformed (list): coordinates of :math:`\theta_{ML}` in the unit cube :math:`[0, 1]^{d}`
             - paramnames (list): input parameter names
-            - insertion_order_MWW_test (dict): results for the Mann-Whitney U-test; for more information, see the :py:class:`ultranest.netiter.MultiCounter` class or `section 4.5.2 of Buchner 2023 <http://arxiv.org/abs/2101.09675>`_
+            - insertion_order_MWW_test (dict): results for the Mann-Whitney U-test;
+            for more information, see the :py:class:`ultranest.netiter.MultiCounter` class
+            or `section 4.5.2 of Buchner 2023 <http://arxiv.org/abs/2101.09675>`_
                 - independent_iterations (float): shortest insertion order test run length
                 - converged (bool): whether the run is converged according to the MWW test, at the given threshold
         """

--- a/ultranest/integrator.py
+++ b/ultranest/integrator.py
@@ -2392,7 +2392,7 @@ class ReactiveNestedSampler:
             - logz_single (float64): estimate of :math:`\log Z` from a single sampler
             - logzerr_single (float64): estimate of the error :math:`\log Z` from a single sampler
             - logzerr_tail (float64): contribution of the tail (i.e. the terminal leaves of the tree) to the error on :math:`\log Z` (?)
-            - ess (float64): effective sample size, i.e. number of samples divided by the estimated correlation length, estimated as :math:`N / (1 + N^{-1} \sum_i (N w_i - 1)^2)`
+            - ess (float64): effective sample size, i.e. number of samples divided by the estimated correlation length, estimated as :math:`N / (1 + N^{-1} \sum_i (N w_i - 1)^2)` where :math:`w_i` are the sample weights
             - H (float64): `information gained <https://arxiv.org/abs/2205.00009>`_
             - Herr (float64): (Gaussian) :math:`1\sigma` error on :math:`H`
             - posterior (dict): summary information on the posterior marginal distributions for each parameter - a dictionary of lists each with as many items as the fit parameters, indexed as :math:`\theta_i` in the following:
@@ -2403,9 +2403,9 @@ class ReactiveNestedSampler:
                 - errup (list): one-sigma upper quantile of the marginal for :math:`\theta_i`, i.e. 84.1345% quantile
                 - information_gain_bits (list): information gain from the marginal prior on :math:`\theta_i` to the posterior
             - weighted_samples (dict): weighted samples from the posterior, as computed during sampling, sorted by their log-likelihood value
-                - upoints (ndarray): sample locations in the unit cube :math:`[0, 1]^{d}`, where $d$ is the number of parameters - the shape is  `n_iter` by :math:`d`
-                - points (ndarray): sample locations in the physical, user-provided space (same shape as `upoints`)
-                - weights (ndarray): sample weights - shape `n_iter`, they add up to 1
+                - upoints (ndarray): sample locations in the unit cube :math:`[0, 1]^{d}`, where $d$ is the number of parameters - the shape is ``n_iter`` by :math:`d`
+                - points (ndarray): sample locations in the physical, user-provided space (same shape as ``upoints``)
+                - weights (ndarray): sample weights - shape ``n_iter``, they add up to 1
                 - logw (ndarray): ?
                 - bootstrapped_weights (ndarray): ?
                 - logl (ndarray): log-likelihood values at the sample points (?)

--- a/ultranest/integrator.py
+++ b/ultranest/integrator.py
@@ -2438,6 +2438,42 @@ class ReactiveNestedSampler:
         Yields
         ------
         results: dict
+            - niter (int): number of sampler iterations (not likelihood evaluations!)
+            - logz (float64): natural logarithm of the evidence $Z = \int p(d|\theta) p(\theta) \text{d}\theta$
+            - logzerr (float64): $1\sigma$ error on $\log Z$ ([can be safely assumed to be Gaussian](https://github.com/JohannesBuchner/UltraNest/issues/63))
+            - logz_bs (float64): estimate of $\log Z$ from bootstrapping
+            - logzerr_bs (float64): error on the estimate of $\log Z$ from bootstrapping
+            - logz_single (float64): (?)
+            - logzerr_single (float64): (?)
+            - logzerr_tail (float64): remainder integral contribution (?)
+            - ess (float64): effective sample size, i.e. number of samples divided by the estimated correlation length
+            - H (float64): [information gained](https://arxiv.org/abs/2205.00009)
+            - Herr (float64): (Gaussian) $1\sigma$ error on $H$
+            - posterior (dict): summary information on the posterior marginals - a dictionary of lists each with as many items as the fit parameters, indexed as $\theta_i$ in the following:
+                - mean (list): expectation value of $\theta_i$
+                - stdev (list): standard deviation of $\theta_i$
+                - median (list): median of $\theta_i$
+                - errlo (list): one-sigma lower quantile of the marginal for $\theta_i$, i.e. $15.8655$% quantile
+                - errup (list): one-sigma upper quantile of the marginal for $\theta_i$, i.e. $84.1345$% quantile
+                - information_gain_bits (list): information gain from the marginal prior on $\theta_i$ to the posterior
+        - weighted_samples (dict): weighted samples from the posterior, as computed during sampling, sorted by their log-likelihood value
+            - upoints (ndarray): sample locations in the unit cube $[0, 1]^{d}$, where $d$ is the number of parameters - the shape is  `n_iter` by $d$
+            - points (ndarray): sample locations in the physical, user-provided space (same shape as `upoints`)
+            - weights (ndarray): sample weights - shape `n_iter`, they add to 1
+            - logw (ndarray): ?
+            - bootstrapped_weights (ndarray): ?
+            - logl (ndarray): log-likelihood values at the sample points (?)
+        - samples (ndarray): re-weighted posterior samples: distributed according to $p(\theta | d)$ - these points are not sorted, and can be assumed to have been randomly shuffled (?)
+        - maximum_likelihood (dict): summary information on the maximum likelihood value $\theta_{ML}$ found by the posterior exploration
+            - logl (float64): value of the log-likelihood at this point: $p(d | \theta_{ML})$
+            - point (list): coordinates of $\theta_{ML}$ in the physical space
+            - point_untransformed (list): coordinates of $\theta_{ML}$ in the unit cube
+        - ncall (int): total number of likelihood evaluations (accepted and not)
+        - paramnames (list): input parameter names
+        - insertion_order_MWW_test (dict): results for the MWW test (?, what is [Buchner+21 in prep](https://johannesbuchner.github.io/UltraNest/performance.html#output-files)?)
+            - independent_iterations (float)
+            - converged (bool)
+
         """
         # frac_remain=1  means 1:1 -> dlogz=log(0.5)
         # frac_remain=0.1 means 1:10 -> dlogz=log(0.1)

--- a/ultranest/integrator.py
+++ b/ultranest/integrator.py
@@ -2376,12 +2376,12 @@ class ReactiveNestedSampler:
             of initial live points so that once the plateau is traversed,
             *min_num_live_points* live points remain, but not more than
             *widen_before_initial_plateau_num_warn*.
-            
-            
+
+
         Returns
         ------
         results (dict): Results dictionary, with the following entries:
-                
+
             - samples (ndarray): re-weighted posterior samples: distributed according to :math:`p(\theta | d)` - these points are not sorted, and can be assumed to have been randomly shuffled. See :py:func:`ultranest.utils.resample_equal` for more details.
             - logz (float64): natural logarithm of the evidence :math:`\log Z = \log \int p(d|\theta) p(\theta) \text{d}\theta`
             - logzerr (float64): global estimate of the :math:`1\sigma` error on :math:`\log Z` (`can be safely assumed to be Gaussian <https://github.com/JohannesBuchner/UltraNest/issues/63>`_); obtained as the quadratic sum of ``logz_bs`` and ``logz_tail``. Users are advised to use ``logz`` :math:`\pm` ``logzerr`` as the best estimate for the evidence and its error.
@@ -2478,12 +2478,11 @@ class ReactiveNestedSampler:
 
         Yields
         ------
-        
+
         results (dict):
-        
             Results dictionary computed at the current iteration, with the same
-            keys as discussed in the :py:meth:`run` method. 
-        """
+            keys as discussed in the :py:meth:`run` method.
+"""
         # frac_remain=1  means 1:1 -> dlogz=log(0.5)
         # frac_remain=0.1 means 1:10 -> dlogz=log(0.1)
         # dlogz_min = log(1./(1 + frac_remain))


### PR DESCRIPTION
Hi, this is a draft PR to solve #119; it is still incomplete, also due to some trouble I had when building the documentation.

The first point is that I don't know if the formatting is correct since I cannot build the docs: after installing everything and running `make html` I get an error in the `example-line.ipynb` notebook:
```python 
ValueError                                Traceback (most recent call last)
Cell In[14], line 5
      2 bins=np.linspace(0.01, 0.2, 64+1)
      3 scatter_samples = result['samples'][:,2]
----> 5 pdf, _ = fastKDE.pdf(scatter_samples, axes=(bins,))
      6 plt.plot(bins, pdf, color='k')
      8 from ultranest.plot import PredictionBand

ValueError: too many values to unpack (expected 2)
ValueError: too many values to unpack (expected 2)

You can ignore this error by setting the following in conf.py:

    nbsphinx_allow_errors = True
```

If I allow errors in the `conf.py`, however, the API docs seem not to get built at all...
I am on the latest version of ultranest as well as fastkde (2.0.1) so I don't quite understand what the problem is (the pdf from fastKDE seems to only yield one array).

Anyway, about the actual dictionary entries:
- where may I find some information about the MWW test?
- what is logz_single?
- where may I find more information/a reference for the bootstrap logz estimate?

I think the rest should be mostly OK.