### PR TITLE
Unbiased PopulationSimpleSliceSampler

### DIFF
--- a/examples/test_PopSliceSampler.py
+++ b/examples/test_PopSliceSampler.py
@@ -108,6 +108,14 @@ def main(args):
         import ultranest.popstepsampler as ultrapop
         direction=[ultrapop.generate_cube_oriented_direction,ultrapop.generate_mixture_random_direction,ultrapop.generate_differential_direction,ultrapop.generate_region_random_direction,ultrapop.generate_region_oriented_direction,ultrapop.generate_random_direction]
         sampler.stepsampler = ultrapop.PopulationSimpleSliceSampler(popsize=args.popsize,nsteps=args.nstep,generate_direction=direction[args.direction])
+    if args.Sampler=='SimSliceUnitCube':
+        import ultranest.popstepsampler as ultrapop
+        direction=[ultrapop.generate_cube_oriented_direction,ultrapop.generate_mixture_random_direction,ultrapop.generate_differential_direction,ultrapop.generate_region_random_direction,ultrapop.generate_region_oriented_direction,ultrapop.generate_random_direction]
+        sampler.stepsampler = ultrapop.PopulationSimpleSliceSampler(popsize=args.popsize,nsteps=args.nstep,generate_direction=direction[args.direction])
+    if args.Sampler=='SimSliceScale':
+        import ultranest.popstepsampler as ultrapop
+        direction=[ultrapop.generate_cube_oriented_direction,ultrapop.generate_mixture_random_direction,ultrapop.generate_differential_direction,ultrapop.generate_region_random_direction,ultrapop.generate_region_oriented_direction,ultrapop.generate_random_direction]
+        sampler.stepsampler = ultrapop.PopulationSimpleSliceSampler(popsize=args.popsize,nsteps=args.nstep,generate_direction=direction[args.direction],slice_limit=ultrapop.slice_limit_to_scale,scale=1.0,scale_adapt_factor=args.adapt_scale)
     if args.Sampler=='PopSlice':
         import ultranest.popstepsampler as ultrapop
         direction=[ultrapop.generate_cube_oriented_direction,ultrapop.generate_mixture_random_direction,ultrapop.generate_differential_direction,ultrapop.generate_region_random_direction,ultrapop.generate_region_oriented_direction,ultrapop.generate_random_direction]
@@ -137,8 +145,9 @@ if __name__ == '__main__':
     parser.add_argument('--problem', type=str,required=True,choices=['rosenbrock', 'multishell', 'gaussian', 'eggbox', 'funnel'])
     parser.add_argument('--sigma', type=float, default=1)
     parser.add_argument('--run_type', type=str, default='Normal', choices=['Normal', 'Calibration'])
-    parser.add_argument('--Sampler',type=str,required=True,choices=['SimSlice','PopSlice','Slice','PopGaussWalk'])
+    parser.add_argument('--Sampler',type=str,required=True,choices=['PopSlice','Slice','PopGaussWalk','SimSliceUnitCube','SimSliceScale'])
     parser.add_argument('--popsize', type=int)
     parser.add_argument('--nstep', type=int)
     parser.add_argument('--direction', type=int)
+    parser.add_argument('--adapt_scale', type=float, default=0.9)
     main(parser.parse_args())

--- a/examples/test_PopSliceSampler.py
+++ b/examples/test_PopSliceSampler.py
@@ -115,7 +115,7 @@ def main(args):
     if args.Sampler=='SimSliceScale':
         import ultranest.popstepsampler as ultrapop
         direction=[ultrapop.generate_cube_oriented_direction,ultrapop.generate_mixture_random_direction,ultrapop.generate_differential_direction,ultrapop.generate_region_random_direction,ultrapop.generate_region_oriented_direction,ultrapop.generate_random_direction]
-        sampler.stepsampler = ultrapop.PopulationSimpleSliceSampler(popsize=args.popsize,nsteps=args.nstep,generate_direction=direction[args.direction],slice_limit=ultrapop.slice_limit_to_scale,scale=1.0,scale_adapt_factor=args.adapt_scale)
+        sampler.stepsampler = ultrapop.PopulationSimpleSliceSampler(popsize=args.popsize,nsteps=args.nstep,generate_direction=direction[args.direction],slice_limit=ultrapop.slice_limit_to_scale,scale=1.0,scale_adapt_factor=args.adapt_scale,adapt_slice_scale_target=1.0,norm_prop=4)
     if args.Sampler=='PopSlice':
         import ultranest.popstepsampler as ultrapop
         direction=[ultrapop.generate_cube_oriented_direction,ultrapop.generate_mixture_random_direction,ultrapop.generate_differential_direction,ultrapop.generate_region_random_direction,ultrapop.generate_region_oriented_direction,ultrapop.generate_random_direction]
@@ -149,5 +149,5 @@ if __name__ == '__main__':
     parser.add_argument('--popsize', type=int)
     parser.add_argument('--nstep', type=int)
     parser.add_argument('--direction', type=int)
-    parser.add_argument('--adapt_scale', type=float, default=0.9)
+    parser.add_argument('--adapt_scale', type=float, default=1.0)
     main(parser.parse_args())

--- a/tests/test_popstepsampling.py
+++ b/tests/test_popstepsampling.py
@@ -141,11 +141,11 @@ def test_direction_proposals():
 def test_slice_limit():
 
     slice_limit_func = [slice_limit_to_unitcube, slice_limit_to_scale]
-    fake_tleft = [-0.5, -0.2, -1.5]
-    fake_tright = [0.2, 2.4, 0.2]
+    fake_tleft = np.array([-0.5, -0.2, -1.5])
+    fake_tright = np.array([0.2, 2.4, 0.2])
 
-    fake_tleft_scale = [-0.5, -0.2, -1.]
-    fake_tright_scale = [0.2, 1.0, 0.2]
+    fake_tleft_scale = np.array([-0.5, -0.2, -1.])
+    fake_tright_scale = np.array([0.2, 1.0, 0.2])
 
     true_tleft = [fake_tleft, fake_tleft_scale]
     true_tright = [fake_tright, fake_tright_scale]

--- a/tests/test_popstepsampling.py
+++ b/tests/test_popstepsampling.py
@@ -156,7 +156,7 @@ def test_slice_limit():
         assert np.allclose(tright, true_tright[i]), (tright, true_tright[i])
 
 
-from ultranest.stepfuncs import update_vectorised_slice_sampler
+from ultranest.stepfuncs import update_vectorised_slice_sampler,QuantileDistribution,LinearInterpolator
 
 def test_update_slice_sampler():
     """
@@ -264,6 +264,346 @@ def test_SimpleSliceSampler_SLOW(seed=4):
         assert np.allclose(mean_v, v, atol=1e-10), (mean_v, v)
 
 
+def simple_data():
+    """Simple linear test data"""
+    x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+    return x, y
+    
+    
+def nonlinear_data():
+    """Non-linear test data"""
+    x = np.linspace(0, 10, 20)
+    y = np.sin(x)
+    return x, y
+    
+def test_linear_interpolation_simple():
+    """Test linear interpolator on simple linear data"""
+    
+    
+    x, y = simple_data()
+    interp = LinearInterpolator(x, y, fill_left=0.0, fill_right=8.0)
+    
+    # Test exact points
+    for xi, yi in zip(x, y):
+        assert np.isclose(interp(xi), yi, atol=1e-10)
+    
+    # Test midpoints (should be exact for linear data)
+    assert np.isclose(interp(0.5), 1.0, atol=1e-10)
+    assert np.isclose(interp(1.5), 3.0, atol=1e-10)
+    assert np.isclose(interp(2.5), 5.0, atol=1e-10)
+    
+def test_linear_vs_scipy():
+    """Compare LinearInterpolator against scipy.interpolate.interp1d"""
+    
+    from scipy.interpolate import interp1d 
+    x, y = nonlinear_data()
+    
+    # Create both interpolators
+    cython_interp = LinearInterpolator(x, y, fill_left=y[0], fill_right=y[-1])
+    scipy_interp = interp1d(x, y, kind='linear', bounds_error=False, 
+                   fill_value=(y[0], y[-1]))
+    
+    # Test at various points
+    test_points = np.linspace(x[0], x[-1], 50)
+    cython_results = np.array([cython_interp(xi) for xi in test_points])
+    scipy_results = scipy_interp(test_points)
+    
+    np.testing.assert_allclose(cython_results, scipy_results, rtol=1e-10)
+    
+def test_boundary_conditions():
+    """Test fill_left and fill_right behavior"""
+    
+    
+    x, y = simple_data()
+    interp = LinearInterpolator(x, y, fill_left=-999.0, fill_right=999.0)
+    
+    # Test left boundary
+    assert interp(-10.0) == -999.0,f"Expected -999.0, got {interp(-10.0)}"
+    assert interp(0.0) == 0.0,f"Expected 0.0, got {interp(0.01)}"
+    
+    # Test right boundary
+    assert interp(10.0) == 999.0,f"Expected 999.0, got {interp(10.0)}"
+    assert interp(4.0) == 8.0,f"Expected 8.0, got {interp(4.0)}"
+    
+def test_dense_interpolation():
+    """Test interpolation at many dense points"""
+    
+    from scipy.interpolate import interp1d 
+    x = np.linspace(0, 100, 1000)
+    y = np.cos(x) * np.exp(-x / 50)
+    
+    interp = LinearInterpolator(x, y, fill_left=y[0], fill_right=y[-1])
+    scipy_interp = interp1d(x, y, kind='linear', bounds_error=False,
+                   fill_value=(y[0], y[-1]))
+    
+    # Test at 500 random points
+    test_points = np.random.uniform(x[0], x[-1], 500)
+    cython_results = np.array([interp(xi) for xi in test_points])
+    scipy_results = scipy_interp(test_points)
+    
+    np.testing.assert_allclose(cython_results, scipy_results, rtol=1e-10)
+ 
+ 
+def normal_quantiles():
+    """Generate quantiles from normal distribution"""
+    np.random.seed(42)
+    popsize = 5
+    n_quantiles = 10
+    
+    # Create synthetic "live points" from normal distribution
+    projected_live_points = np.random.normal(0, 1, size=(100, popsize))
+    
+    
+    
+    # Compute quantiles
+    quantiles_points = np.linspace(0, 100, n_quantiles)
+    quantiles = np.percentile(projected_live_points, quantiles_points, axis=0)
+    
+    return quantiles, quantiles_points, popsize
+    
+
+def uniform_quantiles():
+    """Generate quantiles from uniform distribution"""
+    np.random.seed(42)
+    popsize = 3
+    n_quantiles = 8
+    
+    # Uniform samples
+    samples = np.random.uniform(0, 1, size=(200, popsize))
+    
+    quantiles_points = np.linspace(0, 100, n_quantiles)
+    quantiles = np.percentile(samples, quantiles_points, axis=0)
+    
+    return quantiles, quantiles_points, popsize
+    
+def test_cdf_ppf_inverse_property():
+    """Test that CDF and PPF are exact inverses"""
+    
+    
+    quantiles, quantiles_points, popsize = normal_quantiles()
+    dist = QuantileDistribution(quantiles, quantiles_points, popsize)
+    
+    # Create test points uniformly distributed in probability space
+    test_probs = np.linspace(0.01, 0.99, 50)
+    worker_indices = np.zeros(len(test_probs), dtype=int)
+    
+    # PPF then CDF should return original probabilities
+    ppf_vals = dist.ppf(test_probs, worker_indices)
+    cdf_vals = dist.cdf(ppf_vals, worker_indices)
+    
+    np.testing.assert_allclose(cdf_vals, test_probs, rtol=1e-6, atol=1e-8)
+    
+    # Test for each worker
+    for w in range(popsize):
+        worker_indices = np.full(len(test_probs), w, dtype=int)
+        ppf_vals = dist.ppf(test_probs, worker_indices)
+        cdf_vals = dist.cdf(ppf_vals, worker_indices)
+        np.testing.assert_allclose(cdf_vals, test_probs, rtol=1e-6, atol=1e-8)
+    
+def test_cdf_ppf_round_trip_data_space( ):
+    """Test CDF->PPF->CDF round-trip in data space"""
+    
+    
+    quantiles, quantiles_points, popsize = normal_quantiles()
+    dist = QuantileDistribution(quantiles, quantiles_points, popsize)
+    
+    # Start with data space values
+    test_values = np.linspace(-1,1 , 40)
+    worker_indices = np.zeros(len(test_values), dtype=int)
+    # CDF to probability space, then PPF back to data space
+    probs = dist.cdf(test_values, worker_indices)
+    recovered_values = dist.ppf(probs, worker_indices)
+    
+    assert np.allclose(recovered_values, test_values),f"{recovered_values} != {test_values}"
+    
+def test_cdf_bounds( ):
+    """Test that CDF values are always in [0, 1]"""
+    
+    
+    quantiles, quantiles_points, popsize = normal_quantiles()
+    dist = QuantileDistribution(quantiles, quantiles_points, popsize)
+    
+    # Test values far outside the quantile range
+    test_values = np.concatenate([
+        np.linspace(quantiles.min() - 100, quantiles.min() - 1, 10),
+        np.linspace(quantiles.max() + 1, quantiles.max() + 100, 10)
+    ])
+    worker_indices = np.full(len(test_values), 0, dtype=int)
+    
+    cdf_vals = dist.cdf(test_values, worker_indices)
+    
+    # Should respect fill values
+    assert np.all(cdf_vals[test_values < quantiles[:, 0].min()] >= 0)
+    assert np.all(cdf_vals[test_values > quantiles[:, 0].max()] <= 1)
+    
+def test_ppf_bounds( ):
+    """Test that PPF returns values within quantile range"""
+    
+    
+    quantiles, quantiles_points, popsize = normal_quantiles()
+    dist = QuantileDistribution(quantiles, quantiles_points, popsize)
+    
+    # Test edge probabilities
+    test_probs = np.array([0.0, 0.001, 0.1, 0.5, 0.9, 0.999, 1.0])
+    
+    for w in range(popsize):
+        worker_indices = np.full(len(test_probs), w, dtype=int)
+        ppf_vals = dist.ppf(test_probs, worker_indices)
+        
+        # PPF values should be within or very close to quantile bounds
+        q_min, q_max = quantiles[:, w].min(), quantiles[:, w].max()
+        assert np.all(ppf_vals >= q_min - 1e-5)
+        assert np.all(ppf_vals <= q_max + 1e-5)
+    
+
+    
+def test_logpdf_monotonicity_around_mode( ):
+    """Test that logpdf has reasonable shape (single peak for normal)"""
+    
+    
+    quantiles, quantiles_points, popsize = normal_quantiles()
+    dist = QuantileDistribution(quantiles, quantiles_points, popsize)
+    
+    # Get the median (mode for symmetric distribution)
+    median_idx = np.argmin(np.abs(quantiles_points - 50))
+    median_val = quantiles[median_idx, 0]
+    
+    # Test values around the median
+    half_width = (quantiles[:, 0].max() - quantiles[:, 0].min()) / 4
+    test_values = np.linspace(median_val - half_width, median_val + half_width, 30)
+    worker_indices = np.zeros(len(test_values), dtype=int)
+    
+    logpdf_vals = dist.logpdf(test_values, worker_indices)
+    
+    # Find the peak
+    peak_idx = np.argmax(logpdf_vals)
+    
+    # Should have a single peak, not oscillating
+    assert peak_idx > 0 and peak_idx < len(logpdf_vals) - 1
+    
+def test_logpdf_consistency_across_workers():
+    """Test that logpdf works consistently for different workers"""
+    
+    
+    quantiles, quantiles_points, popsize = normal_quantiles()
+    dist = QuantileDistribution(quantiles, quantiles_points, popsize)
+    
+    test_values = np.array([0.0, 0.5, 1.0])
+    
+    for w in range(popsize):
+        worker_indices = np.full(len(test_values), w, dtype=int)
+        logpdf_vals = dist.logpdf(test_values, worker_indices)
+        
+        assert np.all(np.isfinite(logpdf_vals))
+        assert len(logpdf_vals) == len(test_values)
+    
+def test_setup_as_described():
+    """Test using the exact setup described in the requirements"""
+    
+    
+    np.random.seed(42)
+    popsize = 5
+    
+    # Generate synthetic data
+    projected_live_points = np.random.normal(0, 1, size=(100, popsize))
+    
+       
+    # Setup quantiles
+    quantiles_points = np.linspace(0, 100, 10)
+    quantiles = np.percentile(projected_live_points, quantiles_points, axis=0)
+    #print(quantiles.shape, quantiles_points.shape,popsize)
+    # Create distribution
+    dist = QuantileDistribution(quantiles, quantiles_points, popsize)
+    worker_running = np.arange(popsize, dtype=int)
+    
+    # Create test data
+    tleft_unitcube = np.random.uniform(0, 1, size=popsize)
+    
+    # Test the pipeline
+    tleft_cdf = dist.cdf(tleft_unitcube, worker_running)
+    tleft_reverse = dist.ppf(tleft_cdf, worker_running)
+    logpdf = dist.logpdf(tleft_unitcube, worker_running)
+    
+    # Check outputs
+    assert tleft_cdf.shape == tleft_unitcube.shape
+    assert tleft_reverse.shape == tleft_unitcube.shape
+    assert logpdf.shape == tleft_unitcube.shape
+    
+    # CDF should be in [0, 1]
+    assert np.all(tleft_cdf >= 0) and np.all(tleft_cdf <= 1)
+    
+    # PPF should invert CDF
+    assert np.allclose(tleft_unitcube,tleft_reverse)
+    
+    # Logpdf should be finite
+    assert np.all(np.isfinite(logpdf))
+ 
+ 
+def test_full_pipeline_with_normal_samples():
+    """Test complete pipeline with normal distribution samples"""
+    
+    from scipy.stats import norm,rv_histogram 
+    np.random.seed(50)
+    popsize = 1
+    n_samples = 1000
+    
+    # Generate samples from different normal distributions
+    loc=np.random.uniform(-5, 5, popsize)
+    scale=np.random.uniform(0.5, 2, popsize)
+    samples = np.random.normal(loc=loc,
+                   scale=scale,
+                   size=(n_samples, popsize))
+     
+    quantiles_points = np.linspace(0, 100, 50)
+    quantiles = np.percentile(samples, quantiles_points, axis=0)
+    
+    dist = QuantileDistribution(quantiles, quantiles_points, popsize)
+    Approx_dist = [rv_histogram(np.histogram(samples[:, w], bins=50, density=True),density=True) for w in range(popsize)]
+    # Generate test points in probability space
+    probs = np.random.uniform(0.01, 0.99, 500)
+    
+    # Test each worker
+    for w in range(popsize):
+        worker_indices = np.full(len(probs), w, dtype=int)
+        
+        # Forward and inverse transforms
+        values = dist.ppf(probs, worker_indices)
+        recovered_probs = dist.cdf(values, worker_indices)
+        
+        # Check round-trip
+        np.testing.assert_allclose(recovered_probs, probs, rtol=1e-5)
+        
+        # Get log-pdf
+        True_logpdf = norm.logpdf(values, loc=loc[w], scale=scale[w])
+        rv_hist_logpdf = Approx_dist[w].logpdf(values)
+        logpdf_vals = dist.logpdf(values, worker_indices)
+        mean_diff_true = np.where(np.isfinite((True_logpdf-logpdf_vals)/True_logpdf), (True_logpdf-logpdf_vals)/True_logpdf, 0)
+        mean_diff_rvhist = np.where(np.isfinite((rv_hist_logpdf-logpdf_vals)/rv_hist_logpdf), (rv_hist_logpdf-logpdf_vals)/rv_hist_logpdf, 0)
+        mean_diff_true_rvhist = np.where(np.isfinite((True_logpdf-rv_hist_logpdf)/True_logpdf), (True_logpdf-rv_hist_logpdf)/True_logpdf, 0)
+        print(f"Worker {w}: Mean relative difference (True vs Quantile): {np.mean(mean_diff_true)} Mean relative difference (rv_hist vs Quantile): {np.mean(mean_diff_rvhist)} Mean relative difference (True vs rv_hist): {np.mean(mean_diff_true_rvhist)}")
+        assert np.all(np.isfinite(logpdf_vals))
+    
+def test_edge_cases():
+    """Test edge cases and boundary conditions"""
+    
+    
+    # Minimal quantiles
+    quantiles = np.array([[0.0, 10.0], [5.0, 15.0], [10.0, 20.0]]).T
+    quantiles_points = np.array([0.0, 50.0, 100.0])
+    popsize = 2
+    test_points = np.array([5.0,15.0])
+    dist = QuantileDistribution(quantiles, quantiles_points, popsize)
+    
+    worker_indices = np.array([0, 1], dtype=int)
+    
+    # Test at mid points
+    cdf_vals = dist.cdf(test_points, worker_indices)
+    assert np.all(np.isfinite(cdf_vals))
+    
+    
+ 
+
 
     
 def test_direction_proposal_values():
@@ -295,8 +635,21 @@ if __name__ == '__main__':
     #test_stepsampler_cubegausswalk()
     #test_stepsampler_randomSimSlice()
     #test_direction_proposals()
-    test_slice_limit()
+    #test_slice_limit()
     #test_update_slice_sampler()
     #Test_SimpleSliceSampler(4)
+    test_edge_cases()
+    test_full_pipeline_with_normal_samples()
+    test_setup_as_described()
+    test_logpdf_consistency_across_workers()    
+    test_logpdf_monotonicity_around_mode( )
+    test_ppf_bounds( )
+    test_cdf_bounds( )
+    test_cdf_ppf_round_trip_data_space( )
+    test_linear_vs_scipy()
+    test_cdf_ppf_inverse_property()
+    test_boundary_conditions()
+    test_dense_interpolation()
+    
     
     

--- a/ultranest/popstepsampler.py
+++ b/ultranest/popstepsampler.py
@@ -836,7 +836,7 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
         self.shrink_factor = shrink_factor
         assert shrink_factor >= 1.0, "The shrink factor should be greater than 1.0 to be efficient"
 
-        self.scale = float(scale)/2. # The code work with 2*scale as the slice width
+        self.scale = float(scale)/2.  # The code work with 2*scale as the slice width
 
         self.adapt_slice_scale_target = adapt_slice_scale_target
 

--- a/ultranest/popstepsampler.py
+++ b/ultranest/popstepsampler.py
@@ -722,7 +722,7 @@ def slice_limit_to_unitcube(tleft, tright):
 
 
 def slice_limit_to_scale(tleft, tright):
-    """Return -1..+1 or the intersection between slice and unit cube if that is shorter.
+    """Return an interval of size 2 including t=0 with a random starting point or the intersection between slice and unit cube if that is shorter.
 
     parameters
     ----------
@@ -735,8 +735,9 @@ def slice_limit_to_scale(tleft, tright):
         (tleft_new,tright_new): tuple
                 Positive and negative slice limits
     """
-    tleft_new = np.fmax(tleft, -1. + np.zeros_like(tleft))
-    tright_new = np.fmin(tright, 1. + np.zeros_like(tright))
+    u = 2.*np.random.uniform(size=tleft.shape)
+    tleft_new = np.fmax(tleft, -u)
+    tright_new = np.fmin(tright, 2.-u)
 
     return tleft_new, tright_new
 
@@ -833,7 +834,7 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
         self.shrink_factor = shrink_factor
         assert shrink_factor >= 1.0, "The shrink factor should be greater than 1.0 to be efficient"
 
-        self.scale = float(scale)
+        self.scale = float(scale)/2. # The code work with 2*scale as the slice width
 
         self.adapt_slice_scale_target = adapt_slice_scale_target
 

--- a/ultranest/popstepsampler.py
+++ b/ultranest/popstepsampler.py
@@ -836,7 +836,7 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
         self.shrink_factor = shrink_factor
         assert shrink_factor >= 1.0, "The shrink factor should be greater than 1.0 to be efficient"
 
-        self.scale = float(scale)/2.  # The code work with 2*scale as the slice width
+        self.scale = float(scale) / 2.  # The code work with 2*scale as the slice width
 
         self.adapt_slice_scale_target = adapt_slice_scale_target
 

--- a/ultranest/popstepsampler.py
+++ b/ultranest/popstepsampler.py
@@ -737,9 +737,9 @@ def slice_limit_to_scale(tleft, tright):
     tnew: tuple
         Positive and negative slice limits, `(tleft_new, tright_new) = tnew`
     """
-    u = 2.*np.random.uniform(size=tleft.shape)
-    tleft_new = np.fmax(tleft, -u)
-    tright_new = np.fmin(tright, 2.-u)
+    u = 2. * np.random.uniform(size=tleft.shape)
+    tleft_new = np.fmax(tleft, - u)
+    tright_new = np.fmin(tright, 2. - u)
 
     return tleft_new, tright_new
 

--- a/ultranest/popstepsampler.py
+++ b/ultranest/popstepsampler.py
@@ -19,7 +19,7 @@ from ultranest.stepfuncs import (evolve, generate_cube_oriented_direction,
                                  generate_random_direction,
                                  generate_region_oriented_direction,
                                  generate_region_random_direction, int_dtype,
-                                 step_back, update_vectorised_slice_sampler)
+                                 step_back, update_vectorised_slice_sampler,process_workers,update_limits_NS,QuantileDistribution)
 from ultranest.utils import submasks
 
 
@@ -777,9 +777,9 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
 
     def __init__(
         self, popsize, nsteps, generate_direction,
-        scale_adapt_factor=1.0, adapt_slice_scale_target=2.0,
+        scale_adapt_factor=1.0, adapt_slice_scale_target=0.5,
         scale=1.0, scale_jitter_func=None, slice_limit=slice_limit_to_unitcube,
-        max_it=100, shrink_factor=1.0
+        max_it=100, shrink_factor=1.0, norm_prop=False
     ):
         """Initialise.
 
@@ -848,6 +848,7 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
         self.popsize = popsize
 
         self.slice_limit = slice_limit
+        self.norm_prop = norm_prop
 
         self.logstat = []
         self.logstat_labels = ['accept_rate', 'efficiency', 'scale', 'far_enough', 'mean_rel_jump']
@@ -860,6 +861,63 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
     def region_changed(self, Ls, region):
         """Act upon region changed. Currently unused."""
         pass
+
+    def stepping_out_NS(self,allu,v,loglike,transform,Lmin,tleft_unitcube,tright_unitcube):
+
+        max_n_left = np.round(np.abs(tleft_unitcube)).astype(int)
+        max_n_right = np.round(np.abs(tright_unitcube)).astype(int)
+        nc= 0
+        Left_limit =allu-v
+        Right_limit = allu+v
+        LogLeftLimit=loglike(transform(Left_limit))
+        LogRightLimit=loglike(transform(Right_limit))
+        nc+=2*self.popsize
+        tLeft_limit = np.ones(self.popsize)
+        tRight_limit = np.ones(self.popsize)
+        # Status indicating if a points has already find its Left limit
+        status_left=np.zeros(self.popsize,dtype=int)
+
+        status_left,Left_limit,tLeft_limit = update_limits_NS(self.popsize,status_left,np.arange(self.popsize),np.ones(self.popsize),LogLeftLimit,Lmin,max_n_left,Left_limit,Left_limit.copy(),tleft_unitcube,tLeft_limit)
+        # Status indicating if a points has already find its right limit
+        status_right=np.zeros(self.popsize,dtype=int)
+        # Checking for first point out of the slice on the left side
+        status_right,Right_limit,tRight_limit = update_limits_NS(self.popsize,status_right,np.arange(self.popsize),np.ones(self.popsize),LogRightLimit,Lmin,max_n_right,Right_limit,Right_limit.copy(),tright_unitcube,tRight_limit)
+
+        worker_running=np.zeros(self.popsize,dtype=int)
+        limit_worker=np.zeros((self.popsize,allu.shape[1]))
+        scale_worker=np.zeros(self.popsize)
+        while np.any(status_left==0):
+        
+           
+            worker_running,scale_worker,limit_worker = process_workers(self.popsize,self.popsize,status_left,worker_running,limit_worker,scale_worker,Left_limit,v,tLeft_limit,1.,-1.)
+
+            limit_worker=np.clip(limit_worker,0,1)
+            LogLimit=loglike(transform(limit_worker))
+
+            nc+=self.popsize
+            
+            status_left,Left_limit,tLeft_limit = update_limits_NS(self.popsize,status_left,worker_running,scale_worker,LogLimit,Lmin,max_n_left,Left_limit,limit_worker,tleft_unitcube,tLeft_limit)
+
+        while np.any(status_right==0):
+        
+           
+            worker_running,scale_worker,limit_worker = process_workers(self.popsize,self.popsize,status_right,worker_running,limit_worker,scale_worker,Right_limit,v,tRight_limit,1.,1.)
+            limit_worker=np.clip(limit_worker,0,1)
+
+            LogLimit=loglike(transform(limit_worker))
+            nc+=self.popsize
+            status_right,Right_limit,tRight_limit = update_limits_NS(self.popsize,status_right,worker_running,scale_worker,LogLimit,Lmin,max_n_right,Right_limit,limit_worker,tright_unitcube,tRight_limit)
+
+        end_scale=np.median(np.fmin(tLeft_limit,tRight_limit))
+        
+        #if end_scale>=self.adapt_slice_scale_target:
+        #    self.scale *= 1./self.scale_adapt_factor
+        #else:
+        #    self.scale *= self.scale_adapt_factor
+        
+
+
+        return -tLeft_limit,tRight_limit, nc
 
     def __next__(
         self, region, Lmin, us, Ls, transform, loglike, ndraw=10,
@@ -906,11 +964,15 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
 
         """
         nlive, ndim = us.shape
-
+        from scipy.stats import truncnorm,norm,kurtosis,tukeylambda
+        from scipy.stats import t as studentt
+        from scipy.interpolate import interp1d
         # fill if empty:
         if len(self.prepared_samples) == 0:
+            
             # choose live points
             ilive = np.random.randint(0, nlive, size=self.popsize)
+            remaining = np.array([np.setdiff1d(np.arange(nlive), [ilive[i]]) for i in range(self.popsize)])
             allu = np.array(us[ilive,:]) if not test else np.array(us)
             allp = np.zeros((self.popsize, ndim)) * np.nan
             allL = np.array(Ls[ilive])
@@ -924,35 +986,136 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
                 factor_scale = self.scale_jitter_func()
                 # Defining slice direction
                 v = self.generate_direction(allu, region, scale=1.0) * self.scale * factor_scale
-
+                if self.norm_prop==2 or self.norm_prop==4: v=v/np.linalg.norm(v,axis=1)[:,None]
                 # limite of the slice based on the unit cube boundaries
                 tleft_unitcube, tright_unitcube = unitcube_line_intersection(allu, v)
-
-                # Defining bound of the slice
-                # Bounds for each points and likelihood calls are identical initially
-
-                # Slice bounds for each likelihood call
-                tleft_worker, tright_worker = self.slice_limit(tleft_unitcube,tright_unitcube)
-
-                # Slice bounds for each points
-                tleft, tright = self.slice_limit(tleft_unitcube,tright_unitcube)
+                if self.norm_prop==1:
+                    #projected_center = np.dot(allu, v)
+                    projected_center = np.einsum('ij,ij->i', allu, v)
+                    #print("Projected center: ", projected_center.shape)
+                    #projected_live_points = np.dot(us, v)-projected_center
+                    projected_live_points = np.einsum('ij,kj->ik', v, us) - projected_center[:,None]
+                    sigma_max = np.max(projected_live_points,axis=1) - np.min(projected_live_points,axis=1)
+                    sigma_min = np.std(projected_live_points,axis=1)
+                    sigma=sigma_max.copy()
+                if self.norm_prop==2:
+                    #v=v/np.linalg.norm(v,axis=1)[:,None]
+                    #std_livepoints = np.std(us,axis=0)
+                    projected_center = np.einsum('ij,ij->i', allu, v)
+                    projected_live_points = np.einsum('ij,ikj->ik', v, us[remaining,:])
+                    
+                    #projected_live_points = np.clip(projected_live_points, (tleft_unitcube+projected_center)[:,None]+1e-5, (tright_unitcube+projected_center)[:,None]-1e-5)
+                    regularization_points = (tleft_unitcube[None,:] + (tright_unitcube-tleft_unitcube)[None,:]*np.random.rand(int(projected_live_points.shape[1]))[:,None]+projected_center[None,:]).swapaxes(0,1)
+                    #print(regularization_points.shape, projected_live_points.shape)
+                    quantiles_points=np.linspace(0,100,50)
+                    #print(np.hstack((projected_live_points, regularization_points)).shape)
+                    index_selected=np.random.choice(np.arange(projected_live_points.shape[1]), size=int(projected_live_points.shape[1]*0.5), replace=False)
+                    selected_project_points = projected_live_points[:,index_selected]
+                    #w = us[:, None, :] - allu[None, :, :]
+                    
+                    #dist_to_line = np.sqrt(np.sum((w - (projected_live_points.swapaxes(0,1)[:,:,None]-projected_center[None,:, None]) * v[None,:,:])**2, axis=2))
+                    #selected_project_points = projected_live_points.copy()
+                    #bad_points = (dist_to_line>np.std(dist_to_line,axis=0)*10.).swapaxes(0,1)
+                    #print(regularization_points.shape, projected_live_points.shape, selected_project_points.shape, bad_points.shape)
+                    #print("Selected projected points: ",dist_to_line.shape,bad_points.shape, np.mean(np.sum(bad_points,axis=1)),np.std(dist_to_line,axis=0),np.min(dist_to_line,axis=0))
+                    #selected_project_points[bad_points]=(tleft_unitcube[None,:] + (tright_unitcube-tleft_unitcube)[None,:]*np.random.rand(int(projected_live_points.shape[1]))[:,None]+projected_center[None,:]).swapaxes(0,1)[bad_points]
+                    
+                    
+                    quantiles = np.percentile(np.hstack((selected_project_points, regularization_points)), quantiles_points, axis=1)#np.percentile(np.hstack((selected_project_points, regularization_points)), quantiles_points, axis=1)#np.percentile( regularization_points, quantiles_points, axis=1)#np.percentile(np.hstack((projected_live_points, regularization_points)), quantiles_points, axis=1)
+                    
+                    dist = QuantileDistribution(quantiles, quantiles_points, self.popsize)
+                    
+                if self.norm_prop==4:
+                    
+                    projected_center = np.einsum('ij,ij->i', allu, v)
+                    
+                    projected_live_points = np.einsum('ij,ikj->ik', v, us[remaining,:])-projected_center[:,None]
+                    
+                    max_left = np.min(projected_live_points,axis=1)*3.
+                    max_right = np.max(projected_live_points,axis=1)*3.
+                    
+                    tleft_unitcube = np.maximum(max_left, tleft_unitcube)
+                    tright_unitcube = np.minimum(max_right, tright_unitcube)
+                    tleft=tleft_unitcube.copy()
+                    tright=tright_unitcube.copy()
+                    tleft_worker = tleft.copy()
+                    tright_worker = tright.copy()
                 # Index of the workers working concurrently
                 worker_running = np.arange(self.popsize, dtype=int_dtype)
+                # Defining bound of the slice
+                # Bounds for each points and likelihood calls are identical initially
+                
+                # Slice bounds for each likelihood call
+
+                if self.norm_prop==3:
+                    tleft,tright,nc_step = self.stepping_out_NS(allu,v,loglike,transform,Lmin,tleft_unitcube,tright_unitcube)
+                    tright_worker = tright.copy()
+                    tleft_worker = tleft.copy()
+                    nc+=nc_step
+                if self.norm_prop==1 or self.norm_prop==0:
+                    tleft_worker, tright_worker = self.slice_limit(tleft_unitcube,tright_unitcube)
+                
+                    # Slice bounds for each points
+                    tleft, tright = self.slice_limit(tleft_unitcube,tright_unitcube)
+                if self.norm_prop==2:
+                    tleft_unitcube+=projected_center
+                    tright_unitcube+=projected_center
+                    #tleft_unitcube = np.zeros_like(projected_center)
+                    #tright_unitcube = np.zeros_like(projected_center)+1.
+                    #print("tleft_unitcube: ", tleft_unitcube.shape)
+                    tleft_unitcube = dist.cdf(tleft_unitcube,worker_running)
+                    #print("tleft_unitcube: ", tleft_unitcube)
+                    #print("tleft_unitcube: ", tleft_unitcube.shape)
+                    tright_unitcube = dist.cdf(tright_unitcube, worker_running)
+                    #print("tright_unitcube: ", tright_unitcube)
+                    allu_proj = dist.cdf(projected_center,worker_running)
+                    logquantile = dist.logpdf(projected_center, worker_running)
+                    tleft, tright = tleft_unitcube-allu_proj, tright_unitcube-allu_proj
+                    tleft_worker, tright_worker = tleft[worker_running].copy(), tright[worker_running].copy()
+                    Likelihood_threshold = np.log(np.random.uniform(size=(self.popsize,))) - logquantile
+                expected_end_width=np.sqrt((tright-tleft)**2/12) # Expected width of uniform distribution on slice
+                
                 # Status indicating if a points has already find its next position
                 status = np.zeros(self.popsize, dtype=int_dtype)  # one for success, zero for running
-
+                
                 # Loop until each points has found its next position or we reached 100 iterations
                 for _it in range(self.max_it):
                     # Sampling points on the slices
-                    slice_position = np.random.uniform(size=(self.popsize,))
-                    t = tleft_worker + (tright_worker - tleft_worker) * slice_position
+                    if self.norm_prop==1:
+                        t = truncnorm.rvs((tleft_worker) / sigma[worker_running], (tright_worker) / sigma[worker_running], loc=0, scale=sigma[worker_running], size=(self.popsize,))
 
-                    points = allu[worker_running, :]
-                    v_worker = v[worker_running, :]
-                    proposed_u = points + t.reshape((-1,1)) * v_worker
+                        MH_acceptance =truncnorm.logpdf(-t , (tleft_worker) / sigma[worker_running], (tright_worker) / sigma[worker_running], loc=t, scale=sigma[worker_running]) - truncnorm.logpdf(0., (tleft_worker) / sigma[worker_running], (tright_worker) / sigma[worker_running], loc=0, scale=sigma[worker_running])
+                        accepted = MH_acceptance >= np.log(np.random.uniform(size=(self.popsize,)))
+                        #accepted = np.ones(self.popsize, dtype=bool)
 
-                    proposed_p = transform(proposed_u)
-                    proposed_L = loglike(proposed_p)
+                        points = allu[worker_running, :]
+                        v_worker = v[worker_running, :]
+                        proposed_u = points + t.reshape((-1,1)) * v_worker
+                        proposed_p = transform(proposed_u)
+                        proposed_L = loglike(proposed_p)
+                        proposed_L[~accepted] = -np.inf
+                    elif self.norm_prop==2:
+                        slice_position = np.random.uniform(size=(self.popsize,))
+                        t = tleft_worker + (tright_worker - tleft_worker) * slice_position
+                        t_real = t +allu_proj[worker_running]
+                        t_real = dist.ppf(t_real,worker_running)
+                        proposed_u = allu[worker_running] + (t_real - projected_center[worker_running]).reshape((-1,1)) * v[worker_running, :]
+                        proposed_p = transform(proposed_u)
+                        proposed_L = loglike(proposed_p)
+                        proposed_logquantile = dist.logpdf(t_real,worker_running)
+                        accepted = -proposed_logquantile >= Likelihood_threshold[worker_running]
+                        proposed_L[~accepted] = -np.inf
+                    else:
+                        slice_position = np.random.uniform(size=(self.popsize,))
+                        t = tleft_worker + (tright_worker - tleft_worker) * slice_position
+
+                        points = allu[worker_running, :]
+                        v_worker = v[worker_running, :]
+                        proposed_u = points + t.reshape((-1,1)) * v_worker
+                        proposed_p = transform(proposed_u)
+                        proposed_L = loglike(proposed_p)
+
+                    
                     nc += self.popsize
 
                     # Updating the pool of points based on the newly sampled points
@@ -964,12 +1127,15 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
                     # Update of the limits of the slices
                     tleft_worker = tleft[worker_running]
                     tright_worker = tright[worker_running]
-
+                    if self.norm_prop==1:
+                        sigma[worker_running]=sigma[worker_running]/2.
+                        sigma[sigma<sigma_min]=sigma_min[sigma<sigma_min]
                     if not np.any(status == 0):
                         break
 
                 # Record of the final interval on theta for scale adaptation
-                interval_final += np.median(tright - tleft)
+                interval_final += np.mean(np.abs(t[status == 1])/expected_end_width[status == 1])
+#np.mean((tright - tleft) / expected_end_width)
 
             interval_final = interval_final / self.nsteps
             self.discarded += n_discarded
@@ -990,10 +1156,11 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
             # Scale adaptation such that the final interval is
             # half the scale. There may be better things to do
             # here, but it seems to work.
-            if interval_final >= 1. / self.adapt_slice_scale_target:
+            if interval_final >= self.adapt_slice_scale_target and self.scale>1e-10 and self.scale<np.sqrt(ndim):
                 self.scale *= 1. / self.scale_adapt_factor
             else:
                 self.scale *= self.scale_adapt_factor
+            #print(interval_final, self.adapt_slice_scale_target, self.scale)
             # print("percentage of throws %.3f\n\n"%((self.throwed/self.ncalls)*100.))
 
         else:
@@ -1001,6 +1168,7 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
 
         u, p, L = self.prepared_samples.pop(0)
         return u, p, L, nc
+
 
 
 __all__ = [

--- a/ultranest/popstepsampler.py
+++ b/ultranest/popstepsampler.py
@@ -980,7 +980,9 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
             n_discarded = 0
 
             interval_final = 0.
-
+            if self.norm_prop==5:
+                n_good_call=0
+                n_bad_call = 0
             for _k in range(self.nsteps):
                 # Defining scale jitter
                 factor_scale = self.scale_jitter_func()
@@ -1040,13 +1042,23 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
                     tright=tright_unitcube.copy()
                     tleft_worker = tleft.copy()
                     tright_worker = tright.copy()
+                if self.norm_prop==5:
+                    from scipy.stats import norm
+                    projected_center = np.einsum('ij,ij->i', allu, v)
+                    allu_proj = np.zeros_like(projected_center)+0.5
+                    tright = norm.cdf(tright_unitcube, loc=0.0, scale=self.scale)-allu_proj
+                    tleft = norm.cdf(tleft_unitcube, loc=0.0, scale=self.scale)-allu_proj
+                    #print("tleft, tright: ", tleft, tright) 
+                    
                 # Index of the workers working concurrently
                 worker_running = np.arange(self.popsize, dtype=int_dtype)
                 # Defining bound of the slice
                 # Bounds for each points and likelihood calls are identical initially
                 
                 # Slice bounds for each likelihood call
-
+                if self.norm_prop==5:
+                    tleft_worker = tleft.copy()
+                    tright_worker = tright.copy()
                 if self.norm_prop==3:
                     tleft,tright,nc_step = self.stepping_out_NS(allu,v,loglike,transform,Lmin,tleft_unitcube,tright_unitcube)
                     tright_worker = tright.copy()
@@ -1105,6 +1117,17 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
                         proposed_logquantile = dist.logpdf(t_real,worker_running)
                         accepted = -proposed_logquantile >= Likelihood_threshold[worker_running]
                         proposed_L[~accepted] = -np.inf
+                    elif self.norm_prop==5:
+                        slice_position = np.random.uniform(size=(self.popsize,))
+                        t = tleft_worker + (tright_worker - tleft_worker) * slice_position
+                        t_real = t+allu_proj[worker_running] 
+                        t_real = norm.ppf(t_real,loc=0., scale=self.scale)
+                        proposed_u = allu[worker_running] + (t_real).reshape((-1,1)) * v[worker_running, :]
+                        proposed_p = transform(proposed_u)
+                        proposed_L = loglike(proposed_p)
+                        n_good_call += np.sum(proposed_L > Lmin)
+                        n_bad_call += np.sum(proposed_L <= Lmin)
+                        
                     else:
                         slice_position = np.random.uniform(size=(self.popsize,))
                         t = tleft_worker + (tright_worker - tleft_worker) * slice_position
@@ -1152,14 +1175,22 @@ class PopulationSimpleSliceSampler(GenericPopulationSampler):
                 np.mean(far_enough) if len(far_enough) > 0 else 0,
                 np.exp(np.mean(np.log(move_distance / reference_distance + 1e-10))) if len(far_enough) > 0 else 0
             ])
-
-            # Scale adaptation such that the final interval is
-            # half the scale. There may be better things to do
-            # here, but it seems to work.
-            if interval_final >= self.adapt_slice_scale_target and self.scale>1e-10 and self.scale<np.sqrt(ndim):
-                self.scale *= 1. / self.scale_adapt_factor
+            if self.norm_prop!=5:
+                # Scale adaptation such that the final interval is
+                # half the scale. There may be better things to do
+                # here, but it seems to work.
+                if interval_final >= self.adapt_slice_scale_target and self.scale>1e-10 and self.scale<np.sqrt(ndim):
+                    self.scale *= 1. / self.scale_adapt_factor
+                else:
+                    self.scale *= self.scale_adapt_factor
             else:
-                self.scale *= self.scale_adapt_factor
+                # Assume the same thing as RW
+                #print("scale",self.scale, "n_good_call", n_good_call/(n_good_call+n_bad_call), "n_bad_call", n_bad_call)
+                if n_good_call/(n_good_call+n_bad_call)>0.234:
+                    self.scale *= 1. / self.scale_adapt_factor
+                else:
+                    self.scale *= self.scale_adapt_factor
+                self.scale=np.clip(self.scale, 1e-20,20)
             #print(interval_final, self.adapt_slice_scale_target, self.scale)
             # print("percentage of throws %.3f\n\n"%((self.throwed/self.ncalls)*100.))
 

--- a/ultranest/stepfuncs.pyx
+++ b/ultranest/stepfuncs.pyx
@@ -11,6 +11,8 @@ np.import_array()
 from numpy import nan as np_nan
 cimport cython
 from cython.parallel import prange
+from libc.math cimport log, fmax
+
 
 
 ctypedef np.int64_t decl_int_t
@@ -628,3 +630,439 @@ cpdef tuple update_vectorised_slice_sampler(
                 j += 1
 
     return (tleft, tright, worker_running, status, allu, allL, allp,discarded)
+
+
+ctypedef np.float64_t float_t
+#ctypedef np.int32_t decl_int_t
+
+# Define the integer dtype used elsewhere in the code
+#int_dtype = np.int32
+
+
+cdef class LinearInterpolator:
+    """Fast Cython linear interpolator replacing scipy.interpolate.interp1d"""
+    
+    cdef float_t[:] x_data
+    cdef float_t[:] y_data
+    cdef double fill_left
+    cdef double fill_right
+    cdef int n_points
+    
+    def __init__(self, np.ndarray x, np.ndarray y, double fill_left=0.0, double fill_right=1.0):
+        """
+        Initialize linear interpolator.
+        
+        Parameters:
+        -----------
+        x : ndarray, shape (n,)
+            X coordinates (must be sorted)
+        y : ndarray, shape (n,)
+            Y coordinates
+        fill_left : float
+            Value to return for x < x[0]
+        fill_right : float
+            Value to return for x > x[-1]
+        """
+        # Convert to contiguous float64 arrays and store as memoryviews
+        x_arr = np.ascontiguousarray(x, dtype=np.float64)
+        y_arr = np.ascontiguousarray(y, dtype=np.float64)
+        
+        self.x_data = x_arr
+        self.y_data = y_arr
+        self.fill_left = fill_left
+        self.fill_right = fill_right
+        self.n_points = len(x)
+    
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef double evaluate(self, double x_val) noexcept:
+        """
+        Fast linear interpolation for a single point.
+        This is a cdef function, so it's called without Python overhead.
+        """
+        cdef:
+            float_t[:] x_data = self.x_data
+            float_t[:] y_data = self.y_data
+            int idx, n = self.n_points
+            double x0, x1, y0, y1, t
+        
+        # Check boundaries
+        if x_val < x_data[0]:
+            return self.fill_left
+        if x_val > x_data[n - 1]:
+            return self.fill_right
+        
+        # Binary search for the interval
+        idx = self._binary_search(x_val)
+        
+        # Linear interpolation
+        x0 = <double>x_data[idx]
+        x1 = <double>x_data[idx + 1]
+        y0 = <double>y_data[idx]
+        y1 = <double>y_data[idx + 1]
+        
+        t = (x_val - x0) / (x1 - x0)
+        return y0 + t * (y1 - y0)
+    
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cdef int _binary_search(self, double x_val) noexcept:
+        """Binary search to find the interval containing x_val"""
+        cdef:
+            float_t[:] x_data = self.x_data
+            int left = 0, right = self.n_points - 1, mid
+        
+        while left < right:
+            mid = (left + right) >> 1
+            if x_data[mid] < x_val:
+                left = mid + 1
+            else:
+                right = mid
+        
+        return left - 1
+    
+    def __call__(self, double x_val):
+        """Allow interpolator to be called like a function"""
+        return self.evaluate(x_val)
+
+
+cdef class QuantileDistribution:
+    """Cython-optimized quantile-based distribution functions using memoryviews."""
+    
+    cdef int popsize
+    cdef float_t[:, ::1] quantiles  # C-contiguous memoryview
+    cdef float_t[::1] quantiles_points
+    cdef list cdf_fns
+    cdef list ppf_fns
+    cdef float_t[:, ::1] pdf_slopes  # C-contiguous memoryview
+    
+    def __init__(self, np.ndarray quantiles, np.ndarray quantiles_points, int popsize):
+        """
+        Initialize the distribution.
+        
+        Parameters:
+        -----------
+        quantiles : ndarray of shape (n_quantiles, popsize)
+            Quantile values for each worker
+        quantiles_points : ndarray of shape (n_quantiles,)
+            Percentile points (0-100)
+        popsize : int
+            Number of workers
+        """
+        # Convert to C-contiguous float64 arrays
+        quantiles_arr = np.ascontiguousarray(quantiles, dtype=np.float64)
+        quantiles_points_arr = np.ascontiguousarray(quantiles_points, dtype=np.float64)
+        
+        # Store as memoryviews
+        self.quantiles = quantiles_arr
+        self.quantiles_points = quantiles_points_arr
+        self.popsize = popsize
+        
+        # Pre-compute interpolation functions
+        self._build_cdf_ppf_functions()
+        self._build_pdf_slopes()
+    
+    cdef _build_cdf_ppf_functions(self):
+        """Build CDF and PPF linear interpolation functions."""
+        self.cdf_fns = []
+        self.ppf_fns = []
+        
+        cdef:
+            int w
+            LinearInterpolator cdf_fn, ppf_fn
+            np.ndarray quantiles_norm_py
+        
+        # Convert memoryview to numpy array for mathematical operations
+        quantiles_points_py = np.asarray(self.quantiles_points)
+        quantiles_norm_py = np.ascontiguousarray(
+            quantiles_points_py / 100.0, dtype=np.float64
+        )
+        
+        for w in range(self.popsize):
+            # Extract column as a numpy array (necessary for LinearInterpolator)
+            quantiles_col = np.asarray(self.quantiles[:, w])
+            
+            # CDF: maps quantile values -> probabilities
+            cdf_fn = LinearInterpolator(
+                quantiles_col,
+                quantiles_norm_py,
+                fill_left=0.0,
+                fill_right=1.0
+            )
+            self.cdf_fns.append(cdf_fn)
+            
+            # PPF (inverse CDF): maps probabilities -> quantile values
+            ppf_fn = LinearInterpolator(
+                quantiles_norm_py,
+                quantiles_col,
+                fill_left=<double>self.quantiles[0, w],
+                fill_right=<double>self.quantiles[-1, w]
+            )
+            self.ppf_fns.append(ppf_fn)
+    
+    cdef _build_pdf_slopes(self):
+        """Pre-compute PDF slopes for efficient log-pdf calculation."""
+        cdef:
+            np.ndarray quantiles_py = np.asarray(self.quantiles)
+            np.ndarray quantiles_points_py = np.asarray(self.quantiles_points)
+            np.ndarray dq_arr
+            np.ndarray dq_vals_arr
+            np.ndarray slopes_arr
+
+        """
+        # Perform numpy operations on numpy arrays
+        dq_arr = np.diff(quantiles_points_py / 100.0)
+        dq_vals_arr = np.diff(quantiles_py, axis=0)
+        
+        # Avoid division by zero
+        dq_vals_arr = np.maximum(dq_vals_arr, 1e-12)
+        
+        # Compute slopes: dq / dq_vals
+        slopes_arr = dq_arr[:, None] / dq_vals_arr
+        
+        # Store as C-contiguous array (will be automatically converted to memoryview)
+        self.pdf_slopes = np.ascontiguousarray(slopes_arr, dtype=np.float64)
+        """
+        p = quantiles_points_py / 100.0
+
+        mass = np.diff(p)
+        width = np.diff(quantiles_py, axis=0)
+        width = np.maximum(width, 1e-12)  # Avoid division by zero
+
+        norm = mass.sum(axis=0)
+        
+        slopes_arr = mass[:, None] / width
+
+        slopes_arr /= norm
+        self.pdf_slopes = np.ascontiguousarray(slopes_arr, dtype=np.float64)
+    
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    def cdf(self, np.ndarray x_points, np.ndarray worker):
+        """
+        Evaluate CDF at given points for each worker.
+        
+        Parameters:
+        -----------
+        x_points : ndarray of shape (n,)
+            Points at which to evaluate CDF
+        worker : ndarray of shape (n,), dtype int
+            Worker indices
+        
+        Returns:
+        --------
+        cdf_values : ndarray of shape (n,)
+            CDF values
+        """
+        x_points = np.ascontiguousarray(x_points, dtype=np.float64)
+        worker = np.ascontiguousarray(worker, dtype=int_dtype)
+        
+        cdef:
+            float_t[::1] x_view = x_points
+            decl_int_t[::1] worker_view = worker
+            int n = len(x_points)
+            np.ndarray[float_t, ndim=1] out = np.empty(n, dtype=np.float64)
+            int i, w
+            LinearInterpolator cdf_fn
+        
+        for i in range(n):
+            w = <int>worker_view[i]
+            cdf_fn = self.cdf_fns[w]
+            out[i] = <float_t>cdf_fn.evaluate(<double>x_view[i])
+        
+        return out
+    
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    def ppf(self, np.ndarray q_points, np.ndarray worker):
+        """
+        Evaluate PPF (inverse CDF) at given points for each worker.
+        
+        Parameters:
+        -----------
+        q_points : ndarray of shape (n,)
+            Quantile points (probabilities)
+        worker : ndarray of shape (n,), dtype int
+            Worker indices
+        
+        Returns:
+        --------
+        ppf_values : ndarray of shape (n,)
+            PPF values
+        """
+        q_points = np.ascontiguousarray(q_points, dtype=np.float64)
+        worker = np.ascontiguousarray(worker, dtype=int_dtype)
+        
+        cdef:
+            float_t[::1] q_view = q_points
+            decl_int_t[::1] worker_view = worker
+            int n = len(q_points)
+            np.ndarray[float_t, ndim=1] out = np.empty(n, dtype=np.float64)
+            int i, w
+            LinearInterpolator ppf_fn
+        
+        for i in range(n):
+            w = <int>worker_view[i]
+            ppf_fn = self.ppf_fns[w]
+            out[i] = <float_t>ppf_fn.evaluate(<double>q_view[i])
+        
+        return out
+    
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    def logpdf(self, np.ndarray x, np.ndarray worker):
+        """
+        Evaluate log-PDF at given points for each worker.
+
+        Matches scipy.stats.rv_histogram:
+          - constant density within each quantile interval
+          - logpdf = -inf outside the support
+        """
+        x = np.ascontiguousarray(x, dtype=np.float64)
+        worker = np.ascontiguousarray(worker, dtype=int_dtype)
+
+        cdef:
+            float_t[::1] x_view = x
+            decl_int_t[::1] worker_view = worker
+            float_t[:, ::1] quantiles = self.quantiles
+            float_t[:, ::1] pdf_slopes = self.pdf_slopes
+            int W = x.shape[0]
+            int n_quantiles = quantiles.shape[0]
+            np.ndarray[float_t, ndim=1] out = np.empty(W, dtype=np.float64)
+
+            int i, w, idx
+            double xi, slope
+
+        for i in range(W):
+            w = <int>worker_view[i]
+            xi = <double>x_view[i]
+
+            # largest j such that quantiles[j,w] <= xi
+            idx = self._search_interval_cdef(
+                quantiles,
+                w,
+                xi,
+                n_quantiles
+            )
+
+            # Outside support -> pdf = 0 -> logpdf = -inf
+            if idx < 0 or idx >= n_quantiles - 1:
+                out[i] = -np.inf
+                continue
+
+            slope = <double>pdf_slopes[idx, w]
+
+            if slope <= 0.0:
+                out[i] = -np.inf
+            else:
+                out[i] = log(slope)
+
+        return out
+    
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cdef int _search_interval_cdef(
+            self,
+            float_t[:, ::1] quantiles,
+            int w,
+            double xval,
+            int n_quantiles) noexcept:
+        """
+        Binary search to find the interval containing xval for worker w.
+        Operates directly on memoryviews for maximum speed.
+        """
+        cdef:
+            int left = 0, right = n_quantiles, mid
+        
+        while left < right:
+            mid = (left + right) >> 1
+            if quantiles[mid, w] <= xval:
+                left = mid + 1
+            else:
+                right = mid
+        
+        return left - 1
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+def process_workers(
+    decl_int_t popsize,
+    decl_int_t npoints,
+    np.ndarray[decl_int_t, ndim=1] status,
+    np.ndarray[decl_int_t, ndim=1] worker_running,
+    np.ndarray[np.float_t, ndim=2] limit_worker,
+    np.ndarray[np.float_t, ndim=1] scale_worker,
+    np.ndarray[np.float_t, ndim=2] limit,
+    np.ndarray[np.float_t, ndim=2] v,
+    np.ndarray[np.float_t, ndim=1] end_scale,
+    np.float_t scale,
+    np.float_t sign):
+    """Cython function to process workers for stepping (C-level loops)"""
+    cdef int j = 0
+    cdef int k
+    cdef int n_scale=1
+    
+    # Assign workers
+
+    while j<popsize and (status==0).any():
+        for k in range(npoints):
+            if status[k]==0 and j<popsize:
+                worker_running[j] = k
+                for dim in range(limit_worker.shape[1]):
+                    limit_worker[j, dim] = limit[k, dim] +sign * n_scale * scale * v[k, dim]
+                scale_worker[j] = n_scale+end_scale[k]
+                j += 1
+        n_scale += 1
+        
+    return (worker_running, scale_worker, limit_worker)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+def update_limits_NS(
+    decl_int_t popsize,
+    np.ndarray[decl_int_t, ndim=1] status,
+    np.ndarray[decl_int_t, ndim=1] worker_running,
+    np.ndarray[np.float_t, ndim=1] scale_worker,
+    np.ndarray[np.float_t, ndim=1] LogLimit,
+    np.float_t Lmin,
+    np.ndarray[decl_int_t, ndim=1] max_n,
+    np.ndarray[np.float_t, ndim=2] limit,
+    np.ndarray[np.float_t, ndim=2] limit_worker,
+    np.ndarray[np.float_t, ndim=1] t_unitcube,
+    np.ndarray[np.float_t, ndim=1] end_scale
+):
+    """Cython function to update limits (C-level loops)"""
+    cdef int l, worker_idx
+    cdef int dims = limit.shape[1]
+    
+    for l in range(popsize):
+        worker_idx = worker_running[l]
+        # Check if scale exceeds maximum
+        if scale_worker[l] > max_n[worker_idx] and status[worker_idx] == 0:
+            status[worker_idx] = 1
+            #for dim in range(dims):
+            #    limit[worker_idx, dim] = t_unitcube[worker_idx]
+            end_scale[worker_idx] = np.abs(t_unitcube[worker_idx])
+        # Check likelihood threshold
+        if LogLimit[l] > Lmin  and status[worker_idx] == 0:
+            for dim in range(dims):
+                limit[worker_idx, dim] = limit_worker[l, dim]
+            #end_scale[worker_idx] = scale_worker[l]
+            end_scale[worker_idx] += 1 # should be in order
+        if LogLimit[l] < Lmin and status[worker_idx] == 0:
+            status[worker_idx] = 1
+            if max_n[worker_idx] >end_scale[worker_idx] + 1:
+                end_scale[worker_idx] += 1
+            else:
+                end_scale[worker_idx] = np.abs(t_unitcube[worker_idx])
+
+            #end_scale[worker_idx] += scale_worker[l]
+    return (status, limit, end_scale)
+
+
+


### PR DESCRIPTION
Hi there,

I finally found some time to look at #170. The code modifications are quite small. I only changed `slice_limit_to_scale` to include random slice placement. Using the bounds of the unit cube as the slice limit should be unbiased too, it is one of the methods proposed in Neal's paper, so I kept it that way.

I end up doing a couple of tests with a Rosenbrock 30D with the normal slice sampler, this slice sampler with the slice to the unit cube and finally with the scale. I use the scale adaptation, but not the shrink factor or jitter. With the modification, it appears to be slightly biased depending on how the scale is adapted. From my tests, it seems to perform better at recovering the same logz as the others with stronger adaptation, like 0.8 or 0.7. In all cases, it leads to fewer likelihood calls than the others.


Here is the normal slice sampler as a reference: 

```
time -p python test_PopSliceSampler.py --x_dim 30 --num_live_points 700 --log_dir Rosenbrock_30_Slice --seed 0 --problem rosenbrock --run_type Normal --Sampler Slice --nstep 300 --direction 1

[...]

[ultranest] Explored until L=-5  .43 [-41.5266..-9.6147] | it/evals=129403/211934554 eff=0.0563% N=1400 
[ultranest] Likelihood function evaluations: 211939861
[ultranest] Writing samples and results to disk ...
[ultranest] Writing samples and results to disk ... done
[ultranest]   logZ = -173.2 +- 0.3124
[ultranest] Effective samples strategy satisfied (ESS = 17047.5, need >400)
[ultranest] Posterior uncertainty strategy is satisfied (KL: 0.45+-0.05 nat, need <0.50 nat)
[ultranest] Evidency uncertainty strategy wants 349 minimum live points (dlogz from 0.27 to 0.72, need <0.5)
[ultranest]   logZ error budget: single: 0.34 bs:0.31 tail:0.06 total:0.32 required:<0.50
[ultranest] done iterating.

logZ = -173.243 +- 0.725
  single instance: logZ = -173.243 +- 0.475
  bootstrapped   : logZ = -173.166 +- 0.722
  tail           : logZ = +- 0.064
insert order U test : converged: True correlation: inf iterations
step sampler diagnostic: jump distance 1.09 (should be >1), far enough fraction: 72.68%  (should be >50%)

    param1              : 0.838 │ ▁   ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▅▅▄▃▂▁▁▁▁▁▁▁▁ │1.118     0.998 +- 0.029
    param2              : 0.855 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▆▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.124     0.997 +- 0.029
    param3              : 0.846 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▆▇▇▇▆▅▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.122     0.997 +- 0.029
    param4              : 0.860 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▆▆▇▇▇▆▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.121     0.997 +- 0.029
    param5              : 0.845 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.126     0.997 +- 0.029
    param6              : 0.842 │ ▁  ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁ ▁ │1.123     0.996 +- 0.029
    param7              : 0.854 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁ │1.114     0.997 +- 0.029
    param8              : 0.844 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.125     0.996 +- 0.029
    param9              : 0.845 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▆▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.126     0.997 +- 0.029
    param10             : 0.853 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.127     0.997 +- 0.029
    param11             : 0.832 │ ▁▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▆▅▄▃▂▂▁▁▁▁▁ ▁▁▁ │1.133     0.997 +- 0.029
    param12             : 0.852 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▄▅▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁ ▁ │1.126     0.997 +- 0.029
    param13             : 0.846 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▄▃▃▂▁▁▁▁▁▁▁▁▁ │1.123     0.997 +- 0.029
    param14             : 0.857 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.122     0.997 +- 0.029
    param15             : 0.853 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▆▄▃▂▂▁▁▁▁▁▁▁▁▁▁ │1.133     0.997 +- 0.029
    param16             : 0.852 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.118     0.997 +- 0.029
    param17             : 0.838 │ ▁ ▁▁▁▁▁▁▁▁▁▁▁▂▃▄▅▆▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁ │1.123     0.996 +- 0.029
    param18             : 0.835 │ ▁ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▆▄▃▂▂▁▁▁▁▁▁▁▁ │1.123     0.997 +- 0.029
    param19             : 0.830 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.128     0.996 +- 0.029
    param20             : 0.773 │ ▁ ▁ ▁▁ ▁▁▁▁▁▁▁▁▁▁▂▃▄▅▆▇▇▇▆▅▃▂▂▁▁▁▁▁ ▁ │1.130     0.996 +- 0.029
    param21             : 0.594 │ ▁▁▁ ▁▁ ▁▁ ▁▁ ▁▁▁▁▁▁▁▁▁▁▁▂▃▅▆▇▇▆▄▂▁▁▁▁ │1.118     0.994 +- 0.029
    param22             : 0.299 │ ▁▁   ▁ ▁▁▁  ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▇▄▂▁▁▁ │1.150     0.992 +- 0.031
    param23             : -0.004│ ▁   ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▆▂▁▁ │1.153     0.988 +- 0.036
    param24             : -0.131│ ▁  ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▄▇▆▂▁▁ │1.165     0.981 +- 0.047
    param25             : -0.113│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▄▇▇▅▂▁▁ │1.180     0.968 +- 0.071
    param26             : -0.18 │ ▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▅▆▇▆▄▁▁▁ │1.22      0.94 +- 0.11
    param27             : -0.17 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▃▄▅▆▇▇▇▇▅▃▂▁▁▁ │1.33      0.91 +- 0.17
    param28             : -0.24 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▂▃▃▄▄▅▆▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁ │1.65      0.86 +- 0.27
    param29             : -0.28 │ ▁▁▂▃▄▄▄▅▆▆▇▇▇▇▇▇▇▆▆▅▄▄▃▃▂▂▁▁▁▁▁▁▁▁▁▁▁ │2.60      0.81 +- 0.42
    param30             : -0.50 │ ▁▃▇▆▅▅▄▄▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁▁ │6.28      0.83 +- 0.77

real 4547.22
user 4690.52
sys 7.23
```


Here are some tests with popsize=1:

```
time -p python test_PopSliceSampler.py --x_dim 30 --num_live_points 700 --log_dir Rosenbrock_30_SimSliceUnitCube --seed 0 --problem rosenbrock --run_type Normal --Sampler SimSliceUnitCube --nstep 300 --direction 1 --popsize 1

[...]

[ultranest] Explored until L=-4  .17 [-41.9833..-8.6919] | it/evals=131592/303062927 eff=0.0300% N=1400 
[ultranest] Likelihood function evaluations: 303062927
[ultranest] Writing samples and results to disk ...
[ultranest] Writing samples and results to disk ... done
[ultranest]   logZ = -173.9 +- 0.3104
[ultranest] Effective samples strategy satisfied (ESS = 18859.5, need >400)
[ultranest] Posterior uncertainty strategy is satisfied (KL: 0.46+-0.04 nat, need <0.50 nat)
[ultranest] Evidency uncertainty strategy wants 349 minimum live points (dlogz from 0.25 to 0.64, need <0.5)
[ultranest]   logZ error budget: single: 0.34 bs:0.31 tail:0.03 total:0.31 required:<0.50
[ultranest] done iterating.

logZ = -173.969 +- 0.644
  single instance: logZ = -173.969 +- 0.476
  bootstrapped   : logZ = -173.940 +- 0.644
  tail           : logZ = +- 0.027
insert order U test : converged: True correlation: inf iterations
step sampler diagnostic: jump distance 1.12 (should be >1), far enough fraction: 79.34%  (should be >50%)

    param1              : 0.852 │ ▁ ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁ ▁▁ │1.128     0.998 +- 0.029
    param2              : 0.866 │ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▅▆▇▇▇▇▆▆▅▃▃▂▁▁▁▁▁▁▁▁ ▁ │1.124     0.997 +- 0.029
    param3              : 0.836 │ ▁  ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁ │1.124     0.997 +- 0.029
    param4              : 0.846 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁▁ │1.133     0.997 +- 0.029
    param5              : 0.851 │ ▁▁ ▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.124     0.997 +- 0.029
    param6              : 0.857 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁▁▁ │1.134     0.997 +- 0.029
    param7              : 0.847 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▃▄▅▅▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁▁ │1.132     0.997 +- 0.029
    param8              : 0.833 │ ▁  ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.125     0.997 +- 0.029
    param9              : 0.845 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.123     0.997 +- 0.029
    param10             : 0.829 │ ▁   ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▅▄▃▂▂▁▁▁▁▁▁▁▁ │1.123     0.997 +- 0.029
    param11             : 0.854 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▅▇▇▇▇▇▇▅▅▄▂▂▁▁▁▁▁▁▁▁▁ │1.121     0.996 +- 0.029
    param12             : 0.868 │ ▁▁▁▁▁▁▁▁▁▁▂▂▃▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.115     0.997 +- 0.029
    param13             : 0.843 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▃▄▅▆▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.121     0.997 +- 0.029
    param14             : 0.850 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁  ▁ │1.131     0.997 +- 0.029
    param15             : 0.859 │ ▁▁▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▇▇▇▇▆▅▄▃▃▂▁▁▁▁▁▁▁▁▁▁ │1.128     0.997 +- 0.029
    param16             : 0.862 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.120     0.997 +- 0.029
    param17             : 0.839 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▆▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.128     0.996 +- 0.029
    param18             : 0.735 │ ▁        ▁▁▁▁▁▁▁▁▁▁▂▃▄▅▇▇▇▇▅▄▂▂▁▁▁▁▁▁ │1.128     0.996 +- 0.029
    param19             : 0.716 │ ▁   ▁  ▁   ▁▁▁▁▁▁▁▁▁▂▃▅▆▇▇▇▆▄▃▂▁▁▁▁▁▁ │1.133     0.996 +- 0.029
    param20             : 0.587 │ ▁▁      ▁▁ ▁▁ ▁ ▁▁▁▁▁▁▁▁▂▄▆▇▇▆▄▂▁▁▁▁▁ │1.136     0.996 +- 0.029
    param21             : 0.300 │ ▁▁          ▁ ▁▁▁▁▁ ▁▁▁▁▁▁▁▁▃▆▇▆▃▁▁▁▁ │1.162     0.995 +- 0.030
    param22             : -0.006│ ▁        ▁ ▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▄▁▁▁ │1.163     0.993 +- 0.032
    param23             : -0.200│ ▁     ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▇▇▂▁▁ │1.172     0.989 +- 0.036
    param24             : -0.128│ ▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▅▁▁▁ │1.175     0.982 +- 0.047
    param25             : -0.134│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▅▇▆▂▁▁ │1.170     0.969 +- 0.069
    param26             : -0.18 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▅▇▇▇▄▁▁▁ │1.22      0.95 +- 0.11
    param27             : -0.21 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▃▄▅▆▇▇▇▇▅▃▂▁▁▁ │1.34      0.91 +- 0.17
    param28             : -0.20 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▂▃▃▄▄▅▆▆▇▇▇▇▆▆▅▄▃▂▂▁▁▁▁▁ │1.62      0.85 +- 0.27
    param29             : -0.29 │ ▁▁▁▃▃▄▄▅▅▆▇▇▇▇▇▇▇▆▆▅▅▄▃▃▂▂▁▁▁▁▁▁▁▁▁▁▁ │2.51      0.80 +- 0.42
    param30             : -0.46 │ ▁▃▇▆▅▅▄▄▃▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ │5.89      0.82 +- 0.75

real 8646.14
user 8767.63
sys 9.55


time -p python test_PopSliceSampler.py --x_dim 30 --num_live_points 700 --log_dir Rosenbrock_30_SimSliceScale --seed 0 --problem rosenbrock --run_type Normal --Sampler SimSliceScale --nstep 300 --direction 1 --popsize 1 --adapt_scale 0.9


[ultranest] Explored until L=-6  .59 [-42.4963..-9.0803] | it/evals=130282/145744994 eff=0.0821% N=1400 
[ultranest] Likelihood function evaluations: 145744994
[ultranest] Writing samples and results to disk ...
[ultranest] Writing samples and results to disk ... done
[ultranest]   logZ = -171.8 +- 0.388
[ultranest] Effective samples strategy satisfied (ESS = 19111.3, need >400)
[ultranest] Posterior uncertainty strategy is satisfied (KL: 0.46+-0.05 nat, need <0.50 nat)
[ultranest] Evidency uncertainty strategy wants 349 minimum live points (dlogz from 0.28 to 0.90, need <0.5)
[ultranest]   logZ error budget: single: 0.33 bs:0.39 tail:0.04 total:0.39 required:<0.50
[ultranest] done iterating.

logZ = -171.816 +- 0.904
  single instance: logZ = -171.816 +- 0.473
  bootstrapped   : logZ = -171.780 +- 0.904
  tail           : logZ = +- 0.040
insert order U test : converged: True correlation: 1631 iterations
step sampler diagnostic: jump distance 1.09 (should be >1), far enough fraction: 72.47%  (should be >50%)

    param1              : 0.829 │ ▁  ▁ ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁ │1.119     0.998 +- 0.029
    param2              : 0.843 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁ ▁ │1.127     0.997 +- 0.029
    param3              : 0.842 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▅▅▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁ ▁ │1.136     0.997 +- 0.029
    param4              : 0.853 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.123     0.997 +- 0.029
    param5              : 0.849 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▆▇▇▇▆▆▅▄▃▂▁▁▁▁▁▁▁▁▁▁ │1.132     0.997 +- 0.029
    param6              : 0.835 │ ▁  ▁▁▁▁▁▁▁▁▁▁▂▃▃▅▆▇▇▇▇▆▆▅▃▂▂▁▁▁▁▁▁▁▁▁ │1.131     0.997 +- 0.029
    param7              : 0.859 │ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁  ▁ │1.133     0.997 +- 0.029
    param8              : 0.847 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁ ▁▁ │1.138     0.997 +- 0.029
    param9              : 0.846 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▇▇▇▇▇▇▆▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.127     0.997 +- 0.029
    param10             : 0.854 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▅▃▂▂▁▁▁▁▁▁▁▁ │1.113     0.997 +- 0.029
    param11             : 0.856 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁ │1.114     0.997 +- 0.029
    param12             : 0.849 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁ ▁▁ │1.131     0.997 +- 0.029
    param13             : 0.846 │ ▁  ▁▁▁▁▁▁▁▁▁▂▃▃▅▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.131     0.997 +- 0.029
    param14             : 0.859 │ ▁ ▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁  ▁▁ │1.144     0.997 +- 0.029
    param15             : 0.831 │ ▁ ▁▁▁▁▁▁▁▁▁▁▁▂▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁ ▁ │1.136     0.997 +- 0.029
    param16             : 0.675 │ ▁              ▁▁▁▁▁▁▁▂▃▅▆▇▇▇▅▃▂▁▁▁▁▁ │1.125     0.996 +- 0.029
    param17             : 0.485 │ ▁                 ▁▁ ▁▁▁▁▁▃▅▇▇▆▃▂▁▁▁▁ │1.146     0.996 +- 0.029
    param18             : 0.201 │ ▁                ▁  ▁  ▁▁▁▁▁▁▂▅▇▆▃▁▁▁ │1.152     0.996 +- 0.029
    param19             : 0.027 │ ▁            ▁     ▁  ▁▁ ▁▁▁▁▁▄▇▇▂▁▁▁ │1.179     0.996 +- 0.029
    param20             : -0.074│ ▁        ▁  ▁  ▁  ▁▁ ▁▁▁ ▁▁▁▁▁▁▄▇▅▁▁▁ │1.167     0.995 +- 0.030
    param21             : -0.025│ ▁ ▁ ▁ ▁ ▁ ▁   ▁ ▁▁ ▁▁▁▁▁▁▁▁▁▁▁▂▅▇▄▁▁▁ │1.165     0.994 +- 0.030
    param22             : -0.092│ ▁ ▁ ▁▁ ▁ ▁ ▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▄▁▁▁ │1.176     0.992 +- 0.033
    param23             : -0.150│ ▁▁▁▁▁▁ ▁▁▁▁▁▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▇▇▃▁▁ │1.158     0.988 +- 0.037
    param24             : -0.117│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▄▁▁▁ │1.176     0.981 +- 0.048
    param25             : -0.145│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▄▇▇▄▁▁▁ │1.188     0.967 +- 0.070
    param26             : -0.15 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▅▆▇▇▄▂▁▁ │1.20      0.94 +- 0.11
    param27             : -0.17 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▅▆▇▇▇▆▅▃▁▁▁ │1.29      0.90 +- 0.17
    param28             : -0.21 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▃▃▄▅▅▆▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁ │1.55      0.85 +- 0.26
    param29             : -0.26 │ ▁▁▁▃▃▄▄▅▅▆▇▇▇▇▇▇▇▇▆▆▆▅▄▄▃▃▂▁▁▁▁▁▁▁▁▁▁ │2.32      0.79 +- 0.41
    param30             : -0.41 │ ▁▃▇▇▆▅▅▄▄▃▃▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁ │5.11      0.79 +- 0.70

real 6293.26
user 6432.40
sys 9.24
```

Same here, but with popsize=10: 

```
time -p python test_PopSliceSampler.py --x_dim 30 --num_live_points 700 --log_dir Rosenbrock_30_SimSliceUnitCube --seed 0 --problem rosenbrock --run_type Normal --Sampler SimSliceUnitCube --nstep 300 --direction 1 --popsize 10

[...]

[ultranest] Explored until L=-1e+01  3 [-15.7434..-15.7403]*| it/evals=112103/287879710 eff=0.0389% N=700 
[ultranest] Likelihood function evaluations: 287879710
[ultranest] Writing samples and results to disk ...
[ultranest] Writing samples and results to disk ... done
[ultranest]   logZ = -173.7 +- 0.4289
[ultranest] Effective samples strategy satisfied (ESS = 417.8, need >400)
[ultranest] Posterior uncertainty strategy is satisfied (KL: 0.45+-0.09 nat, need <0.50 nat)
[ultranest] Evidency uncertainty strategy wants 698 minimum live points (dlogz from 0.35 to 0.82, need <0.5)
[ultranest]   logZ error budget: single: 0.47 bs:0.43 tail:0.41 total:0.59 required:<0.50
[ultranest] done iterating.

logZ = -173.690 +- 0.911
  single instance: logZ = -173.690 +- 0.471
  bootstrapped   : logZ = -173.676 +- 0.816
  tail           : logZ = +- 0.405
insert order U test : converged: True correlation: 16218 iterations
step sampler diagnostic: jump distance 1.12 (should be >1), far enough fraction: 78.51%  (should be >50%)

    param1              : 0.857 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▃▅▇▄▆▅▅▅▄▃▃▃▁▁▁▁▁▁▁▁▁▁▁ │1.129     0.996 +- 0.030
    param2              : 0.864 │ ▁▁▁▁▁▁▁▁▁▁▄▂▃▄▅▄▆▇▅▆▅▄▄▂▂▁▁▁▁▁▁▁▁▁  ▁ │1.148     0.997 +- 0.030
    param3              : 0.853 │ ▁▁▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▇▇▆▆▅▅▃▃▂▁▁▁▁▁▁▁▁▁ ▁ │1.145     0.998 +- 0.029
    param4              : 0.839 │ ▁  ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▆▄▄▄▆▇▅▅▄▄▂▂▁▁▁▁▁▁▁▁ │1.115     0.998 +- 0.030
    param5              : 0.842 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▂▃▄▅▆▇▅▅▅▃▃▃▂▂▁▁▁▁▁▁▁ ▁ │1.136     0.998 +- 0.031
    param6              : 0.836 │ ▁   ▁▁▁▁▁▁▁▁▁▂▃▃▅▄▅▇▇▅▅▅▃▂▂▂▁▁▁▁▁▁▁▁▁ │1.135     0.996 +- 0.031
    param7              : 0.845 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▅▄▄▄▇▆▇▆▅▅▇▃▃▂▁▁▁▁▁▁▁▁▁ │1.124     0.997 +- 0.031
    param8              : 0.858 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▂▃▄▄▄▇▄▇▆▆▅▅▃▃▂▂▁▁▁▁▁▁▁▁ │1.121     1.000 +- 0.030
    param9              : 0.852 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▃▄▅▇▆▇▆▆▇▅▄▃▄▁▁▁▁▁▁▁▁ ▁ │1.130     1.000 +- 0.030
    param10             : 0.853 │ ▁▁▁▁▁▁▁▁▁▁▂▂▂▃▃▄▆▅▅▇▅▅▄▃▂▂▁▁▁▁▁▁▁▁  ▁ │1.143     0.999 +- 0.030
    param11             : 0.848 │ ▁ ▁▁▁▁▁▁▁▁▁▁▁▂▂▄▃▆▅▇▇▄▄▃▃▂▂▂▁▁▁▁▁▁▁▁▁ │1.132     0.999 +- 0.030
    param12             : 0.853 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▅▇▅▄▆▅▄▂▂▁▁▁▁▁▁▁▁▁  ▁ │1.142     0.997 +- 0.030
    param13             : 0.862 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▆▅▆▅▆▄▃▂▂▁▁▁▁▁▁▁  ▁ │1.131     0.998 +- 0.030
    param14             : 0.867 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▅▇▆▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁▁ │1.118     0.996 +- 0.029
    param15             : 0.853 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▃▄▅▅▇▆▆▄▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.123     0.997 +- 0.029
    param16             : 0.847 │ ▁ ▁ ▁▁▁▁▁▁▁▂▂▂▃▅▇▅▆▆▆▅▅▆▅▃▂▂▁▁▁▁▁▁▁ ▁ │1.125     0.995 +- 0.030
    param17             : 0.859 │ ▁▁▁▁▁▁▁▁▁▁▁▂▅▃▆▄▆▆▇▇▇▇▅▅▆▅▃▂▂▁▁▁▁▁▁▁▁ │1.118     0.995 +- 0.031
    param18             : 0.838 │ ▁  ▁▁▁▁▁▁▁▁▂▄▃▃▄▄▇▇▆▆▆▆▅▄▃▃▂▁▁▁▁▁▁ ▁▁ │1.135     0.994 +- 0.032
    param19             : 0.737 │ ▁        ▁▁▁▁▁▁▁▁▂▃▄▅▇▇▇▇▆▆▂▂▁▁▁▁▁  ▁ │1.153     0.995 +- 0.031
    param20             : 0.482 │ ▁       ▁    ▁  ▁▁▁▁▁▁▁▁▁▁▃▄▇▇▇▅▂▁▁▁▁ │1.140     0.996 +- 0.031
    param21             : 0.166 │ ▁          ▁ ▁▁▁▁▁▁▁▁▁ ▁▁▁▁▁▁▃▅▇▄▂▁▁▁ │1.166     0.994 +- 0.030
    param22             : 0.059 │ ▁     ▁▁▁▁▁▁▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▇▇▄▁▁▁ │1.161     0.991 +- 0.033
    param23             : -0.090│ ▁  ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▄▇▇▂▁▁ │1.159     0.987 +- 0.039
    param24             : -0.074│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▅▇▅▂▁▁ │1.164     0.978 +- 0.051
    param25             : -0.169│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▅▇▇▄▁▁ │1.158     0.964 +- 0.076
    param26             : -0.16 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▅▅▇▇▇▅▂▁▁ │1.21      0.94 +- 0.12
    param27             : -0.18 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▇▆▆▇▆▇▇▇▃▁▁▁ │1.30      0.90 +- 0.19
    param28             : -0.19 │ ▁▁▁▁▁▁▁▁▁▁▂▂▂▂▃▃▃▄▆▇▆▆▆▆▆▆▆▇▆▇▃▃▂▂▁▁▁ │1.52      0.84 +- 0.28
    param29             : -0.26 │ ▁▁▁▃▄▃▃▄▅▆▇▅▇▆▆▆▅▅▅▄▇▄▅▄▅▃▂▂▂▁▁▁▁▁▁▁▁ │2.17      0.79 +- 0.44
    param30             : -0.44 │ ▁▁▇▇▇▅▅▄▄▃▃▄▂▄▂▁▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁ │4.51      0.82 +- 0.77

real 1211.87
user 1321.03
sys 4.52



time -p python test_PopSliceSampler.py --x_dim 30 --num_live_points 700 --log_dir Rosenbrock_30_SimSliceScale --seed 0 --problem rosenbrock --run_type Normal --Sampler SimSliceScale --nstep 300 --direction 1 --popsize 10

[...]

[ultranest] Explored until L=-1e+01  5 [-15.3600..-15.3585]*| it/evals=110247/136425390 eff=0.0808% N=700 
[ultranest] Likelihood function evaluations: 136425390
[ultranest] Writing samples and results to disk ...
[ultranest] Writing samples and results to disk ... done
[ultranest]   logZ = -170.6 +- 0.3661
[ultranest] Effective samples strategy satisfied (ESS = 565.6, need >400)
[ultranest] Posterior uncertainty strategy is satisfied (KL: 0.44+-0.06 nat, need <0.50 nat)
[ultranest] Evidency uncertainty strategy wants 698 minimum live points (dlogz from 0.32 to 0.84, need <0.5)
[ultranest]   logZ error budget: single: 0.47 bs:0.37 tail:0.41 total:0.55 required:<0.50
[ultranest] done iterating.

logZ = -170.630 +- 0.936
  single instance: logZ = -170.630 +- 0.467
  bootstrapped   : logZ = -170.567 +- 0.843
  tail           : logZ = +- 0.405
insert order U test : converged: False correlation: 4093 iterations
step sampler diagnostic: jump distance 1.08 (should be >1), far enough fraction: 71.41%  (should be >50%)

    param1              : 0.847 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▃▃▃▄▅▆▇▇▅▅▅▃▂▂▁▁▁▁▁▁▁▁ ▁ │1.132     0.998 +- 0.029
    param2              : 0.860 │ ▁ ▁▁▁▁▁▁▁▁▁▃▂▃▃▆▆▆▅▇▇▅▄▃▃▂▂▂▁▁▁▁▁▁▁ ▁ │1.130     0.996 +- 0.031
    param3              : 0.832 │ ▁   ▁▁▁▁▁▁▁▁▁▁▂▂▃▅▅▇▆▇▄▅▄▄▂▂▂▂▁▁▁▁▁▁▁ │1.123     0.997 +- 0.030
    param4              : 0.870 │ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▄▄▅▆▇▅▄▄▃▄▃▁▁▁▁▁▁▁▁▁▁▁ │1.123     0.997 +- 0.030
    param5              : 0.822 │ ▁    ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▅▇▇▆▅▅▄▃▂▂▁▁▁▁▁▁▁▁ │1.129     0.998 +- 0.030
    param6              : 0.855 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▅▅▇▆▇▅▄▄▄▃▂▁▁▁▁▁▁▁▁▁ │1.115     0.997 +- 0.029
    param7              : 0.862 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▅▅▅▇▆▅▅▅▃▂▃▁▁▁▁▁▁▁▁▁▁ │1.120     0.997 +- 0.030
    param8              : 0.854 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▆▇▆▇▆▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.128     0.998 +- 0.029
    param9              : 0.856 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▄▄▄▅▆▆▇▅▅▄▃▂▂▂▁▁▁▁▁▁▁▁▁ │1.121     0.997 +- 0.029
    param10             : 0.835 │ ▁  ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▅▇▆▅▆▄▄▃▂▂▂▁▁▁▁▁▁▁▁ │1.126     0.996 +- 0.029
    param11             : 0.847 │ ▁ ▁▁▁▁▁▁▁▁▁▁▁▃▃▃▄▆▅▇▇▇▇▆▆▄▃▂▂▂▁▁▁▁▁▁▁ │1.114     0.996 +- 0.030
    param12             : 0.843 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▄▆▆▇▆▇▇▆▇▅▄▃▃▁▁▁▁▁▁▁▁▁▁ │1.131     0.996 +- 0.029
    param13             : 0.854 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▃▄▆▆▆▇▅▄▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.120     0.997 +- 0.029
    param14             : 0.861 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▃▄▅▅▇▄▅▆▄▄▂▂▁▁▁▁▁▁▁▁▁▁▁ │1.126     0.996 +- 0.029
    param15             : 0.857 │ ▁▁▁▁▁▁▁▁▁▁▁▃▃▄▄▄▅▆▆▆▇▇▇▄▃▃▁▁▁▁▁▁▁▁▁▁▁ │1.128     0.996 +- 0.030
    param16             : 0.861 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▃▅▅▅▇▇▇▇▆▅▄▃▃▂▁▁▁▁▁▁▁▁▁ │1.117     0.996 +- 0.029
    param17             : 0.760 │ ▁        ▁▁▁▁▁▁▁▁▂▄▃▆▇▇▇▇▆▄▃▂▁▁▁▁▁▁▁▁ │1.139     0.994 +- 0.030
    param18             : 0.627 │ ▁              ▁ ▁▁▁▁▁▂▃▃▅▆▇▇▅▄▂▁▁▁▁▁ │1.133     0.995 +- 0.030
    param19             : 0.386 │ ▁                   ▁▁▁▁▁▁▁▂▅▆▇▅▃▁▁▁▁ │1.149     0.994 +- 0.030
    param20             : 0.150 │ ▁              ▁   ▁   ▁▁▁▁▁▁▂▆▇▇▃▁▁▁ │1.160     0.994 +- 0.031
    param21             : 0.020 │ ▁         ▁   ▁    ▁▁ ▁▁▁▁▁▁▁▁▄▇▆▃▁▁▁ │1.178     0.993 +- 0.032
    param22             : -0.011│ ▁▁   ▁     ▁   ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▆▇▄▁▁▁ │1.165     0.991 +- 0.033
    param23             : -0.023│ ▁▁ ▁▁ ▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▅▂▁▁ │1.157     0.988 +- 0.040
    param24             : -0.063│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▅▂▁▁ │1.159     0.978 +- 0.051
    param25             : -0.133│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▄▇▇▆▂▁▁ │1.172     0.964 +- 0.074
    param26             : -0.20 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▅▆▇▇▅▃▁▁ │1.19      0.94 +- 0.11
    param27             : -0.19 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▄▃▄▆▆▇▇▆▄▄▃▁▁ │1.27      0.90 +- 0.18
    param28             : -0.21 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▃▄▅▄▄▇▇▆▇▆▇▅▆▇▄▄▃▂▂▁▁▁ │1.52      0.84 +- 0.27
    param29             : -0.27 │ ▁▁▁▂▃▃▄▄▄▇▇▆▆▇▆▇▅▆▅▄▇▅▆▄▃▃▂▂▂▂▁▁▁▁▁ ▁ │2.19      0.78 +- 0.42
    param30             : -0.42 │ ▁▁▇▇▇▆▅▄▃▃▃▃▂▃▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁  ▁▁ │4.55      0.79 +- 0.75

real 881.46
user 991.13
sys 4.73
```

Here are the different runs I used to test the factor for scale adaptation. I tested with `scale_adapt_factor=[0.99,0.95,0.85,0.8,0.7,0.5]`, `0.9` is the previous test. For 0.8, 0.7 and 0.5, I got log z ~ 173 instead of the ~170 that I got for the less aggressive adaptation.

```
python test_PopSliceSampler.py --x_dim 30 --num_live_points 700 --log_dir Rosenbrock_30_SimSliceScale --seed 0 --problem rosenbrock --run_type Normal --Sampler SimSliceScale --nstep 300 --direction 1 --popsize 10 --adapt_scale 0.99

[...]

[ultranest] Explored until L=-4  .16 [-40.8769..-7.3660] | it/evals=133542/167879710 eff=0.0757% N=1400 
[ultranest] Likelihood function evaluations: 167879710
[ultranest] Writing samples and results to disk ...
[ultranest] Writing samples and results to disk ... done
[ultranest]   logZ = -171.6 +- 0.3531
[ultranest] Effective samples strategy satisfied (ESS = 19798.6, need >400)
[ultranest] Posterior uncertainty strategy is satisfied (KL: 0.46+-0.04 nat, need <0.50 nat)
[ultranest] Evidency uncertainty strategy wants 349 minimum live points (dlogz from 0.28 to 0.80, need <0.5)
[ultranest]   logZ error budget: single: 0.33 bs:0.35 tail:0.01 total:0.35 required:<0.50
[ultranest] done iterating.

logZ = -171.521 +- 0.630
  single instance: logZ = -171.521 +- 0.473
  bootstrapped   : logZ = -171.619 +- 0.630
  tail           : logZ = +- 0.009
insert order U test : converged: True correlation: 7940 iterations
step sampler diagnostic: jump distance 1.09 (should be >1), far enough fraction: 73.44%  (should be >50%)

    param1              : 0.856 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▄▄▃▂▁▁▁▁▁▁▁▁ ▁ │1.129     0.998 +- 0.028
    param2              : 0.855 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁▁ │1.127     0.997 +- 0.029
    param3              : 0.866 │ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▅▆▇▇▇▇▇▆▅▃▃▂▁▁▁▁▁▁▁▁ ▁ │1.124     0.997 +- 0.029
    param4              : 0.846 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁ ▁ │1.128     0.997 +- 0.029
    param5              : 0.863 │ ▁▁▁▁▁▁▁▁▁▁▂▂▃▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.120     0.996 +- 0.029
    param6              : 0.863 │ ▁▁▁▁▁▁▁▁▁▁▂▃▃▅▆▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁  ▁ │1.144     0.997 +- 0.029
    param7              : 0.857 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁ ▁ │1.121     0.997 +- 0.029
    param8              : 0.829 │ ▁  ▁▁▁▁▁▁▁▁▁▁▁▂▃▄▅▅▇▇▇▇▇▆▄▃▂▂▁▁▁▁▁▁▁▁ │1.123     0.997 +- 0.029
    param9              : 0.855 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁ ▁ │1.126     0.997 +- 0.029
    param10             : 0.840 │ ▁▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁ │1.118     0.997 +- 0.029
    param11             : 0.855 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.120     0.997 +- 0.029
    param12             : 0.840 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▆▆▄▃▂▂▁▁▁▁▁▁ ▁ ▁ │1.140     0.997 +- 0.029
    param13             : 0.829 │ ▁   ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.127     0.997 +- 0.029
    param14             : 0.817 │ ▁  ▁ ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.130     0.997 +- 0.029
    param15             : 0.685 │ ▁            ▁▁▁▁▁▁▁▁▂▃▅▆▇▇▇▅▃▂▁▁▁▁▁▁ │1.135     0.997 +- 0.029
    param16             : 0.483 │ ▁                   ▁▁▁▁▁▂▃▅▇▇▅▂▁▁▁▁▁ │1.155     0.997 +- 0.029
    param17             : 0.295 │ ▁                       ▁▁▁▁▃▆▇▆▃▁▁▁▁ │1.162     0.997 +- 0.029
    param18             : 0.042 │ ▁                          ▁▁▁▂▆▇▄▁▁▁ │1.164     0.997 +- 0.029
    param19             : 0.074 │ ▁                      ▁ ▁▁▁▁▁▂▆▇▅▁▁▁ │1.153     0.996 +- 0.029
    param20             : 0.077 │ ▁              ▁  ▁  ▁▁▁▁▁ ▁▁▁▂▆▇▅▁▁▁ │1.153     0.996 +- 0.029
    param21             : 0.072 │ ▁        ▁ ▁▁▁ ▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▃▇▇▄▁▁▁ │1.158     0.994 +- 0.030
    param22             : -0.040│ ▁   ▁▁ ▁▁  ▁▁▁ ▁  ▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▅▁▁▁ │1.166     0.992 +- 0.032
    param23             : -0.039│ ▁▁▁▁▁▁  ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▆▇▄▁▁▁ │1.170     0.988 +- 0.037
    param24             : -0.060│ ▁▁▁▁▁▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▅▂▁▁ │1.164     0.981 +- 0.048
    param25             : -0.151│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▆▇▅▂▁▁ │1.176     0.967 +- 0.071
    param26             : -0.17 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▄▆▇▇▅▂▁▁ │1.20      0.94 +- 0.11
    param27             : -0.17 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▅▇▇▇▇▆▄▂▁▁▁ │1.30      0.90 +- 0.17
    param28             : -0.25 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▃▃▄▄▅▆▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁ │1.56      0.84 +- 0.26
    param29             : -0.26 │ ▁▁▂▃▃▄▄▅▅▆▇▇▇▇▇▇▇▇▆▆▅▅▄▃▃▂▂▂▁▁▁▁▁▁▁▁▁ │2.33      0.79 +- 0.41
    param30             : -0.45 │ ▁▂▇▇▆▅▅▄▄▃▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁ │5.13      0.78 +- 0.71

real 1160.71
user 1339.52
sys 5.98


python test_PopSliceSampler.py --x_dim 30 --num_live_points 700 --log_dir Rosenbrock_30_SimSliceScale --seed 0 --problem rosenbrock --run_type Normal --Sampler SimSliceScale --nstep 300 --direction 1 --popsize 10 --adapt_scale 0.95

[...]

[ultranest] Explored until L=-5  .98 [-39.5877..-8.5012] | it/evals=130480/163952270 eff=0.0758% N=1400 
[ultranest] Likelihood function evaluations: 163965240
[ultranest] Writing samples and results to disk ...
[ultranest] Writing samples and results to disk ... done
[ultranest]   logZ = -171.8 +- 0.3771
[ultranest] Effective samples strategy satisfied (ESS = 19357.6, need >400)
[ultranest] Posterior uncertainty strategy is satisfied (KL: 0.46+-0.06 nat, need <0.50 nat)
[ultranest] Evidency uncertainty strategy wants 349 minimum live points (dlogz from 0.30 to 0.89, need <0.5)
[ultranest]   logZ error budget: single: 0.33 bs:0.38 tail:0.03 total:0.38 required:<0.50
[ultranest] done iterating.

logZ = -171.899 +- 0.764
  single instance: logZ = -171.899 +- 0.473
  bootstrapped   : logZ = -171.828 +- 0.763
  tail           : logZ = +- 0.030
insert order U test : converged: True correlation: inf iterations
step sampler diagnostic: jump distance 1.08 (should be >1), far enough fraction: 70.17%  (should be >50%)

    param1              : 0.855 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▄▄▃▂▁▁▁▁▁▁▁▁▁▁ │1.130     0.998 +- 0.029
    param2              : 0.858 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.122     0.997 +- 0.029
    param3              : 0.857 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▆▇▇▇▇▇▆▄▃▃▂▁▁▁▁▁▁▁▁▁ │1.121     0.997 +- 0.029
    param4              : 0.858 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▆▇▇▇▇▇▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.121     0.997 +- 0.029
    param5              : 0.858 │ ▁▁▁▁▁▁▁▁▁▁▁▂▃▄▅▆▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁ ▁ │1.132     0.996 +- 0.029
    param6              : 0.861 │ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▃▃▂▁▁▁▁▁▁▁▁  ▁ │1.137     0.997 +- 0.029
    param7              : 0.838 │ ▁▁ ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▅▃▂▂▁▁▁▁▁▁▁▁▁ │1.130     0.996 +- 0.029
    param8              : 0.852 │ ▁▁ ▁▁▁▁▁▁▁▁▂▂▃▄▄▆▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁ ▁ │1.126     0.997 +- 0.029
    param9              : 0.852 │ ▁▁▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁  ▁ │1.143     0.997 +- 0.029
    param10             : 0.860 │ ▁▁▁▁▁▁▁▁▁▁▁▂▃▃▅▆▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁▁ │1.131     0.997 +- 0.028
    param11             : 0.844 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.128     0.996 +- 0.029
    param12             : 0.856 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▃▅▆▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.121     0.997 +- 0.029
    param13             : 0.849 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.120     0.997 +- 0.029
    param14             : 0.796 │ ▁     ▁▁▁▁▁▁▁▁▁▁▂▃▄▅▆▇▇▇▇▆▅▃▂▂▁▁▁▁▁▁▁ │1.126     0.996 +- 0.029
    param15             : 0.634 │ ▁               ▁▁▁▁▁▁▁▂▃▅▇▇▇▆▄▂▁▁▁▁▁ │1.129     0.996 +- 0.029
    param16             : 0.378 │ ▁                     ▁▁▁▁▁▂▄▆▇▆▃▁▁▁▁ │1.148     0.996 +- 0.029
    param17             : 0.154 │ ▁                        ▁▁▁▁▂▅▇▆▂▁▁▁ │1.163     0.996 +- 0.029
    param18             : -0.018│ ▁                       ▁ ▁▁▁▁▁▅▇▅▁▁▁ │1.163     0.996 +- 0.029
    param19             : 0.027 │ ▁               ▁  ▁▁ ▁▁▁▁▁▁▁▁▂▆▇▄▁▁▁ │1.166     0.996 +- 0.029
    param20             : 0.001 │ ▁      ▁   ▁▁ ▁▁ ▁▁ ▁▁▁▁▁▁▁▁▁▁▂▅▇▄▁▁▁ │1.163     0.995 +- 0.029
    param21             : -0.031│ ▁▁ ▁   ▁ ▁ ▁  ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▄▁▁▁ │1.170     0.994 +- 0.031
    param22             : -0.094│ ▁ ▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▇▅▁▁▁ │1.172     0.992 +- 0.034
    param23             : -0.081│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▄▁▁▁ │1.172     0.988 +- 0.040
    param24             : -0.171│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▅▁▁▁ │1.178     0.980 +- 0.051
    param25             : -0.158│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▆▇▅▂▁▁ │1.175     0.967 +- 0.073
    param26             : -0.17 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▄▆▇▇▅▂▁▁ │1.20      0.94 +- 0.11
    param27             : -0.18 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▃▃▄▅▆▇▇▇▆▄▂▁▁▁ │1.31      0.90 +- 0.17
    param28             : -0.24 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▃▃▄▄▅▅▆▆▇▇▇▇▆▆▅▄▃▂▂▁▁▁ │1.52      0.85 +- 0.27
    param29             : -0.28 │ ▁▁▁▂▃▄▄▄▅▅▆▇▇▇▇▇▇▇▇▆▆▅▅▄▄▃▃▂▂▁▁▁▁▁▁▁▁ │2.21      0.79 +- 0.41
    param30             : -0.43 │ ▁▁▇▇▇▆▆▅▄▄▃▃▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁ │4.64      0.79 +- 0.71

real 1146.82
user 1318.51
sys 6.02

python test_PopSliceSampler.py --x_dim 30 --num_live_points 700 --log_dir Rosenbrock_30_SimSliceScale --seed 0 --problem rosenbrock --run_type Normal --Sampler SimSliceScale --nstep 300 --direction 1 --popsize 5 --adapt_scale 0.85

[...]

[ultranest] Explored until L=-1e+01  7 [-15.2693..-15.2658]*| it/evals=108173/133566130 eff=0.0810% N=700 
[ultranest] Likelihood function evaluations: 133578640
[ultranest] Writing samples and results to disk ...
[ultranest] Writing samples and results to disk ... done
[ultranest]   logZ = -167.4 +- 0.3648
[ultranest] Effective samples strategy satisfied (ESS = 473.7, need >400)
[ultranest] Posterior uncertainty strategy is satisfied (KL: 0.45+-0.09 nat, need <0.50 nat)
[ultranest] Evidency uncertainty strategy wants 698 minimum live points (dlogz from 0.29 to 0.87, need <0.5)
[ultranest]   logZ error budget: single: 0.46 bs:0.36 tail:0.41 total:0.55 required:<0.50
[ultranest] done iterating.

logZ = -167.447 +- 0.918
  single instance: logZ = -167.447 +- 0.462
  bootstrapped   : logZ = -167.444 +- 0.824
  tail           : logZ = +- 0.406
insert order U test : converged: True correlation: 100172 iterations
step sampler diagnostic: jump distance 1.08 (should be >1), far enough fraction: 70.17%  (should be >50%)

    param1              : 0.853 │ ▁ ▁▁▁▁▁▁▁▁▁▁▁▂▂▂▄▄▅▅▅▆▇▆▃▃▂▃▁▁▁▁▁▁▁▁▁ │1.113     0.999 +- 0.028
    param2              : 0.854 │ ▁  ▁▁▁▁▁▁▁▁▁▂▂▃▃▅▆▇▇▆▇▆▅▅▃▂▂▁▁▁▁▁▁▁▁▁ │1.121     0.997 +- 0.028
    param3              : 0.848 │ ▁▁ ▁▁▁▁▁▁▁▁▁▂▂▃▄▆▅▆▇▅▅▅▃▃▃▃▁▁▁▁▁▁▁▁ ▁ │1.126     0.996 +- 0.029
    param4              : 0.829 │ ▁  ▁▁▁▁▁▁▁▁▁▁▁▂▂▅▇▆▇▇▆▇▆▇▅▄▂▁▂▁▁▁▁▁ ▁ │1.127     0.997 +- 0.029
    param5              : 0.840 │ ▁ ▁ ▁▁▁▁▁▁▁▁▂▂▃▃▄▇▅▆▇▆▆▅▅▃▃▁▁▁▁▁▁▁▁▁▁ │1.126     0.996 +- 0.029
    param6              : 0.858 │ ▁▁▁▁▁▁▁▁▁▁▂▂▄▃▄▅▅▆▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ ▁ │1.138     0.997 +- 0.030
    param7              : 0.857 │ ▁▁ ▁▁▁▁▁▁▁▁▂▂▄▄▆▆▆▆▇▇▅▅▄▃▃▂▂▁▁▁▁▁▁ ▁▁ │1.133     0.998 +- 0.030
    param8              : 0.861 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▅▄▄▅▇▇▇▇▆▇▄▄▂▃▁▁▁▁▁▁▁▁▁ │1.114     0.998 +- 0.029
    param9              : 0.854 │ ▁ ▁▁▁▁▁▁▁▁▁▂▃▃▃▅▅▅▆▆▇▆▄▃▄▃▂▁▁▁▁▁▁▁▁▁▁ │1.125     0.995 +- 0.030
    param10             : 0.850 │ ▁▁▁ ▁▁▁▁▁▁▁▁▂▂▃▅▅▄▅▇▅▅▄▅▄▂▂▁▁▁▁▁▁▁▁▁▁ │1.131     0.998 +- 0.030
    param11             : 0.854 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▅▅▇▆▅▅▄▂▂▂▁▁▁▁▁▁  ▁▁ │1.134     1.000 +- 0.029
    param12             : 0.861 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▃▅▅▆▇▇▇▇▆▄▅▃▂▂▁▂▁▁▁▁▁▁▁ │1.121     0.998 +- 0.030
    param13             : 0.850 │ ▁ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▅▇▄▄▃▃▂▂▁▁▁▁▁▁▁▁▁ ▁ │1.133     0.998 +- 0.029
    param14             : 0.834 │ ▁  ▁▁▁▁▁▁▁▁▁▁▂▂▃▃▅▅▆▆▇▄▆▄▄▃▂▂▁▁▁▁▁▁▁▁ │1.125     0.997 +- 0.029
    param15             : 0.863 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▄▄▆▅▇▇▅▅▄▄▂▂▂▁▁▁▁▁▁▁▁▁▁ │1.126     0.997 +- 0.028
    param16             : 0.854 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▃▃▄▅▆▅▇▆▄▃▃▃▂▁▁▁▁▁▁▁▁▁▁ │1.121     0.997 +- 0.029
    param17             : 0.847 │ ▁  ▁▁▁▁▁▁▁▁▂▁▂▂▄▅▅▅▇▇▆▅▄▄▃▂▁▁▁▁▁▁▁▁▁▁ │1.122     0.995 +- 0.029
    param18             : 0.744 │ ▁  ▁     ▁ ▁▁▁▁▁▁▁▂▂▃▆▅▇▇▅▅▃▃▁▁▁▁▁▁ ▁ │1.138     0.996 +- 0.029
    param19             : 0.557 │ ▁                ▁▁ ▁▁▁▁▁▂▄▆▇▇▅▃▂▁▁▁▁ │1.133     0.996 +- 0.030
    param20             : 0.277 │ ▁  ▁            ▁▁     ▁▁▁▁▁▁▃▇▇▅▃▁▁▁ │1.146     0.997 +- 0.029
    param21             : 0.027 │ ▁▁           ▁ ▁      ▁▁▁▁▁▁▁▁▂▅▇▅▁▁▁ │1.159     0.996 +- 0.031
    param22             : -0.078│ ▁    ▁    ▁     ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▃▁▁▁ │1.175     0.993 +- 0.032
    param23             : -0.092│ ▁ ▁ ▁ ▁  ▁▁ ▁▁ ▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▄▇▅▁▁▁ │1.165     0.988 +- 0.036
    param24             : -0.112│ ▁▁ ▁▁▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▆▂▁▁ │1.160     0.979 +- 0.048
    param25             : -0.150│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▄▆▇▆▂▁▁ │1.168     0.963 +- 0.072
    param26             : -0.15 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▃▅▆▇▅▂▁▁▁ │1.23      0.94 +- 0.11
    param27             : -0.23 │ ▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▄▅▅▇▆▆▇▆▅▂▁▁ │1.25      0.89 +- 0.17
    param28             : -0.24 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▃▂▅▄▄▆▇▇▇▇▇▇▇▆▆▆▃▃▂▁▁▁ │1.46      0.83 +- 0.26
    param29             : -0.22 │ ▁▁▂▃▃▃▃▃▅▄▆▇▄▇▆▆▆▅▇▄▅▄▅▄▃▄▃▂▂▂▁▁▁▁▁ ▁ │2.04      0.76 +- 0.40
    param30             : -0.39 │ ▁▁▇▇▇▇▅▆▄▄▃▃▂▂▃▂▂▁▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁   ▁ │3.96      0.73 +- 0.66

real 727.06
user 826.37
sys 5.64



python test_PopSliceSampler.py --x_dim 30 --num_live_points 700 --log_dir Rosenbrock_30_SimSliceScale --seed 0 --problem rosenbrock --run_type Normal --Sampler SimSliceScale --nstep 300 --direction 1 --popsize 10 --adapt_scale 0.80

[...]

[ultranest] Explored until L=-6  .04 [-43.0762..-9.2526] | it/evals=132187/165735410 eff=0.0756% N=1400 
[ultranest] Likelihood function evaluations: 165749070
[ultranest] Writing samples and results to disk ...
[ultranest] Writing samples and results to disk ... done
[ultranest]   logZ = -173.8 +- 0.3521
[ultranest] Effective samples strategy satisfied (ESS = 18560.3, need >400)
[ultranest] Posterior uncertainty strategy is satisfied (KL: 0.46+-0.05 nat, need <0.50 nat)
[ultranest] Evidency uncertainty strategy wants 349 minimum live points (dlogz from 0.29 to 0.89, need <0.5)
[ultranest]   logZ error budget: single: 0.34 bs:0.35 tail:0.05 total:0.36 required:<0.50
[ultranest] done iterating.

logZ = -173.782 +- 0.887
  single instance: logZ = -173.782 +- 0.476
  bootstrapped   : logZ = -173.807 +- 0.885
  tail           : logZ = +- 0.053
insert order U test : converged: True correlation: inf iterations
step sampler diagnostic: jump distance 1.08 (should be >1), far enough fraction: 70.67%  (should be >50%)

    param1              : 0.851 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁ ▁▁ │1.137     0.998 +- 0.029
    param2              : 0.857 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▃▄▅▇▇▇▇▇▆▅▄▃▃▂▁▁▁▁▁▁▁▁▁ │1.120     0.997 +- 0.029
    param3              : 0.852 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.119     0.997 +- 0.029
    param4              : 0.853 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.117     0.997 +- 0.029
    param5              : 0.856 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.123     0.997 +- 0.029
    param6              : 0.862 │ ▁▁▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.119     0.997 +- 0.029
    param7              : 0.842 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.130     0.997 +- 0.029
    param8              : 0.854 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁ │1.114     0.997 +- 0.029
    param9              : 0.853 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▅▆▇▇▇▇▆▅▄▃▃▂▁▁▁▁▁▁▁▁ │1.111     0.997 +- 0.029
    param10             : 0.837 │ ▁   ▁▁▁▁▁▁▁▁▁▂▃▃▅▅▇▇▇▇▇▅▄▃▂▂▁▁▁▁▁▁▁ ▁ │1.128     0.996 +- 0.029
    param11             : 0.857 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.121     0.997 +- 0.029
    param12             : 0.864 │ ▁▁▁▁▁▁▁▁▁▁▂▃▄▅▆▆▇▇▇▇▆▆▄▃▂▂▁▁▁▁▁▁▁▁▁▁▁ │1.140     0.997 +- 0.029
    param13             : 0.856 │ ▁ ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁ ▁ │1.124     0.997 +- 0.029
    param14             : 0.854 │ ▁ ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁▁ │1.130     0.997 +- 0.029
    param15             : 0.850 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.127     0.997 +- 0.029
    param16             : 0.758 │ ▁       ▁▁▁▁▁▁▁▁▁▁▂▃▄▆▇▇▇▆▅▃▂▁▁▁▁▁▁▁▁ │1.138     0.996 +- 0.029
    param17             : 0.629 │ ▁          ▁    ▁▁▁▁▁▁▁▂▄▅▇▇▇▅▃▂▁▁▁▁▁ │1.134     0.996 +- 0.029
    param18             : 0.453 │ ▁             ▁      ▁▁▁▁▁▂▃▆▇▇▄▂▁▁▁▁ │1.145     0.996 +- 0.029
    param19             : 0.150 │ ▁            ▁      ▁    ▁▁▁▁▂▅▇▆▃▁▁▁ │1.160     0.996 +- 0.029
    param20             : 0.000 │ ▁       ▁    ▁         ▁▁▁▁▁▁▁▃▇▇▃▁▁▁ │1.176     0.996 +- 0.029
    param21             : -0.100│ ▁     ▁▁        ▁▁  ▁▁ ▁▁▁▁▁▁▁▁▃▇▆▂▁▁ │1.164     0.994 +- 0.030
    param22             : -0.022│ ▁    ▁▁ ▁  ▁▁  ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▆▇▄▁▁▁ │1.167     0.992 +- 0.033
    param23             : -0.125│ ▁ ▁ ▁▁▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▇▇▂▁▁ │1.161     0.988 +- 0.039
    param24             : -0.092│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▅▂▁▁ │1.166     0.979 +- 0.052
    param25             : -0.107│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▆▇▆▂▁▁ │1.164     0.964 +- 0.076
    param26             : -0.16 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▅▆▇▇▄▁▁▁ │1.21      0.94 +- 0.12
    param27             : -0.22 │ ▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▃▄▅▆▇▇▇▇▅▃▁▁▁ │1.29      0.90 +- 0.18
    param28             : -0.27 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▃▃▄▄▅▅▆▇▇▇▇▇▇▆▄▃▂▂▁▁▁▁ │1.55      0.84 +- 0.27
    param29             : -0.28 │ ▁▁▁▂▃▄▄▄▅▅▆▆▇▇▇▇▇▇▇▇▆▅▅▄▄▃▃▂▂▂▁▁▁▁▁▁▁ │2.14      0.77 +- 0.41
    param30             : -0.40 │ ▁▁▇▇▆▆▅▅▄▄▄▃▃▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ │4.35      0.76 +- 0.68

real 1156.45
user 1335.20
sys 6.10


python test_PopSliceSampler.py --x_dim 30 --num_live_points 700 --log_dir Rosenbrock_30_SimSliceScale --seed 0 --problem rosenbrock --run_type Normal --Sampler SimSliceScale --nstep 300 --direction 1 --popsize 5 --adapt_scale 0.70

[...]

[ultranest] Explored until L=-6  .90 [-42.3371..-9.3119] | it/evals=130150/165920130 eff=0.0741% N=1400 
[ultranest] Likelihood function evaluations: 165920130
[ultranest] Writing samples and results to disk ...
[ultranest] Writing samples and results to disk ... done
[ultranest]   logZ = -172.9 +- 0.3057
[ultranest] Effective samples strategy satisfied (ESS = 18714.3, need >400)
[ultranest] Posterior uncertainty strategy is satisfied (KL: 0.46+-0.05 nat, need <0.50 nat)
[ultranest] Evidency uncertainty strategy wants 349 minimum live points (dlogz from 0.26 to 0.61, need <0.5)
[ultranest]   logZ error budget: single: 0.34 bs:0.31 tail:0.05 total:0.31 required:<0.50
[ultranest] done iterating.

logZ = -172.962 +- 0.612
  single instance: logZ = -172.962 +- 0.474
  bootstrapped   : logZ = -172.940 +- 0.609
  tail           : logZ = +- 0.053
insert order U test : converged: True correlation: inf iterations
step sampler diagnostic: jump distance 1.08 (should be >1), far enough fraction: 70.83%  (should be >50%)

    param1              : 0.851 │ ▁▁ ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.121     0.998 +- 0.029
    param2              : 0.862 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▆▇▇▇▆▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.121     0.997 +- 0.029
    param3              : 0.847 │ ▁▁ ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▃▂▁▁▁▁▁▁▁ ▁ │1.125     0.997 +- 0.029
    param4              : 0.845 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.130     0.997 +- 0.029
    param5              : 0.852 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▇▇▇▇▆▆▅▄▃▂▂▁▁▁▁▁▁▁▁ │1.118     0.997 +- 0.029
    param6              : 0.828 │ ▁ ▁  ▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.134     0.997 +- 0.029
    param7              : 0.853 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁ │1.116     0.997 +- 0.029
    param8              : 0.854 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▄▅▅▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.122     0.997 +- 0.029
    param9              : 0.859 │ ▁▁▁▁▁▁▁▁▁▁▂▂▃▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁▁ │1.130     0.997 +- 0.029
    param10             : 0.831 │ ▁▁  ▁▁▁▁▁▁▁▁▁▂▃▄▅▆▇▇▇▇▇▆▄▃▂▂▁▁▁▁▁▁▁ ▁ │1.134     0.997 +- 0.029
    param11             : 0.837 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁▁ │1.134     0.997 +- 0.029
    param12             : 0.822 │ ▁   ▁▁▁▁▁▁▁▁▁▁▂▂▃▅▅▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.128     0.997 +- 0.029
    param13             : 0.840 │ ▁  ▁▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁ │1.121     0.997 +- 0.029
    param14             : 0.860 │ ▁▁▁▁▁▁▁▁▁▁▂▂▃▃▄▅▆▇▇▇▇▆▅▄▃▃▂▁▁▁▁▁▁▁▁▁▁ │1.129     0.997 +- 0.029
    param15             : 0.847 │ ▁  ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.123     0.996 +- 0.029
    param16             : 0.844 │ ▁  ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▆▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.127     0.997 +- 0.029
    param17             : 0.678 │ ▁              ▁▁▁▁▁▁▁▂▄▅▇▇▇▅▄▂▁▁▁▁▁▁ │1.131     0.996 +- 0.029
    param18             : 0.466 │ ▁                 ▁▁ ▁▁▁▁▁▂▄▆▇▆▄▂▁▁▁▁ │1.146     0.996 +- 0.029
    param19             : 0.295 │ ▁                ▁▁▁▁▁▁▁▁▁▁▁▃▆▇▆▃▁▁▁▁ │1.164     0.996 +- 0.029
    param20             : 0.180 │ ▁      ▁     ▁▁▁▁▁▁ ▁ ▁▁▁▁▁▁▁▂▄▇▇▃▁▁▁ │1.148     0.995 +- 0.030
    param21             : -0.004│ ▁ ▁     ▁  ▁▁  ▁  ▁▁▁▁▁▁▁▁▁▁▁▁▂▆▇▄▁▁▁ │1.169     0.994 +- 0.031
    param22             : -0.055│ ▁▁ ▁▁▁▁▁▁▁▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▆▇▄▁▁▁ │1.176     0.992 +- 0.034
    param23             : -0.132│ ▁ ▁▁▁▁▁▁▁▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▇▆▂▁▁ │1.165     0.988 +- 0.040
    param24             : -0.137│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▆▇▄▁▁▁ │1.186     0.979 +- 0.054
    param25             : -0.130│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▄▇▇▄▁▁▁ │1.183     0.963 +- 0.078
    param26             : -0.21 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▄▅▇▇▅▃▁▁ │1.20      0.94 +- 0.12
    param27             : -0.26 │ ▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▃▄▅▆▇▇▇▇▅▃▂▁▁ │1.29      0.89 +- 0.18
    param28             : -0.23 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▃▃▄▄▅▆▆▇▇▇▇▇▇▆▅▄▃▂▁▁▁▁ │1.53      0.83 +- 0.27
    param29             : -0.31 │ ▁▁▁▂▃▃▄▄▅▅▆▆▇▇▇▇▇▇▇▆▆▅▅▄▃▃▂▂▁▁▁▁▁▁▁▁▁ │2.22      0.77 +- 0.41
    param30             : -0.41 │ ▁▂▇▇▆▆▅▄▄▃▃▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁ │4.66      0.76 +- 0.68

real 1120.94
user 1292.26
sys 5.74



python test_PopSliceSampler.py --x_dim 30 --num_live_points 700 --log_dir Rosenbrock_30_SimSliceScale --seed 0 --problem rosenbrock --run_type Normal --Sampler SimSliceScale --nstep 300 --direction 1 --popsize 10 --adapt_scale 0.50

[...]

[ultranest] Explored until L=-6  .25 [-47.6137..-9.8269] | it/evals=130340/162530020 eff=0.0768% N=1400 
[ultranest] Likelihood function evaluations: 162541330
[ultranest] Writing samples and results to disk ...
[ultranest] Writing samples and results to disk ... done
[ultranest]   logZ = -172.8 +- 0.3003
[ultranest] Effective samples strategy satisfied (ESS = 17220.7, need >400)
[ultranest] Posterior uncertainty strategy is satisfied (KL: 0.46+-0.05 nat, need <0.50 nat)
[ultranest] Evidency uncertainty strategy wants 349 minimum live points (dlogz from 0.31 to 0.81, need <0.5)
[ultranest]   logZ error budget: single: 0.34 bs:0.30 tail:0.07 total:0.31 required:<0.50
[ultranest] done iterating.

logZ = -172.970 +- 0.816
  single instance: logZ = -172.970 +- 0.474
  bootstrapped   : logZ = -172.765 +- 0.812
  tail           : logZ = +- 0.075
insert order U test : converged: True correlation: 3508 iterations
step sampler diagnostic: jump distance 1.09 (should be >1), far enough fraction: 73.04%  (should be >50%)

    param1              : 0.841 │ ▁  ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁▁ │1.133     0.997 +- 0.029
    param2              : 0.845 │ ▁▁ ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▄▃▃▂▁▁▁▁▁▁▁▁▁ │1.125     0.997 +- 0.029
    param3              : 0.855 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▆▆▅▄▃▂▁▁▁▁▁▁▁▁▁▁ │1.128     0.997 +- 0.029
    param4              : 0.846 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▃▃▄▅▆▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁▁ │1.130     0.997 +- 0.029
    param5              : 0.860 │ ▁ ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▅▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.121     0.997 +- 0.029
    param6              : 0.841 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▅▅▃▂▂▁▁▁▁▁▁▁▁▁ │1.128     0.997 +- 0.029
    param7              : 0.843 │ ▁ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.123     0.996 +- 0.029
    param8              : 0.853 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁ │1.126     0.997 +- 0.029
    param9              : 0.848 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▄▆▆▇▇▇▆▅▄▄▃▂▁▁▁▁▁▁▁▁ ▁ │1.134     0.997 +- 0.029
    param10             : 0.843 │ ▁  ▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁▁ │1.124     0.997 +- 0.029
    param11             : 0.849 │ ▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▆▇▇▇▇▆▄▄▃▂▁▁▁▁▁▁▁ ▁ │1.121     0.997 +- 0.029
    param12             : 0.866 │ ▁▁▁▁▁▁▁▁▁▁▂▂▃▄▅▆▇▇▇▇▇▇▆▅▄▃▂▁▁▁▁▁▁▁▁ ▁ │1.123     0.996 +- 0.029
    param13             : 0.839 │ ▁ ▁▁▁▁▁▁▁▁▁▁▁▂▃▄▄▆▆▇▇▇▆▆▅▃▃▂▁▁▁▁▁▁▁▁▁ │1.126     0.996 +- 0.029
    param14             : 0.753 │ ▁       ▁▁ ▁▁▁▁▁▁▁▂▂▄▅▆▇▇▇▆▅▃▂▁▁▁▁▁▁▁ │1.130     0.996 +- 0.029
    param15             : 0.640 │ ▁                ▁▁▁▁▁▁▂▄▆▇▇▆▅▃▂▁▁▁▁▁ │1.134     0.997 +- 0.029
    param16             : 0.543 │ ▁                  ▁▁▁▁▁▁▂▄▆▇▇▅▃▁▁▁▁▁ │1.138     0.997 +- 0.029
    param17             : 0.337 │ ▁                       ▁▁▁▁▂▅▇▇▅▂▁▁▁ │1.143     0.997 +- 0.029
    param18             : 0.069 │ ▁                        ▁▁▁▁▁▄▇▆▂▁▁▁ │1.176     0.996 +- 0.029
    param19             : 0.053 │ ▁                    ▁▁▁ ▁▁▁▁▁▂▆▇▄▁▁▁ │1.158     0.996 +- 0.029
    param20             : -0.086│ ▁             ▁  ▁▁ ▁▁▁▁▁▁▁▁▁▁▃▇▆▂▁▁▁ │1.201     0.995 +- 0.030
    param21             : 0.069 │ ▁ ▁    ▁    ▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▇▇▃▁▁▁ │1.165     0.994 +- 0.031
    param22             : -0.057│ ▁ ▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▇▄▁▁▁ │1.168     0.992 +- 0.034
    param23             : -0.130│ ▁ ▁▁▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▇▆▂▁▁ │1.167     0.988 +- 0.041
    param24             : -0.117│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▄▇▇▃▁▁ │1.158     0.980 +- 0.054
    param25             : -0.159│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▆▇▅▂▁▁ │1.180     0.966 +- 0.077
    param26             : -0.19 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▄▆▇▇▅▂▁▁ │1.21      0.94 +- 0.12
    param27             : -0.20 │ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▃▃▄▅▆▇▇▇▇▅▃▁▁▁ │1.29      0.90 +- 0.18
    param28             : -0.21 │ ▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▃▃▄▄▅▆▆▇▇▇▇▇▇▆▄▄▃▂▁▁▁▁ │1.54      0.85 +- 0.27
    param29             : -0.31 │ ▁▁▁▂▃▄▄▄▅▅▆▆▇▇▇▇▇▇▆▆▆▅▅▄▄▃▃▂▂▁▁▁▁▁▁▁▁ │2.25      0.79 +- 0.42
    param30             : -0.41 │ ▁▂▇▇▆▅▅▄▄▃▃▃▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ │4.66      0.80 +- 0.74

real 1119.40
user 1293.07
sys 5.91
```

