### PR TITLE
Corrected comment that had slipped in from a different example

### DIFF
--- a/docs/example-intrinsic-distribution.ipynb
+++ b/docs/example-intrinsic-distribution.ipynb
@@ -139,7 +139,7 @@
     "    # we have to convert them to physical scales\n",
     "    \n",
     "    params = cube.copy()\n",
-    "    # let slope go from -3 to +3\n",
+    "    # let mean go from -100 to +100\n",
     "    lo = -100\n",
     "    hi = +100\n",
     "    params[0] = cube[0] * (hi - lo) + lo\n",


### PR DESCRIPTION
Hello. When working through the tutorials I just noticed that one of the comments on the intrinsic distribution tutorial seemed to have slipped in from the fitting a line tutorial, so I've corrected that. Small thing, but it briefly confused me, so might help others.